### PR TITLE
Add MatchingFilesDatasetOp

### DIFF
--- a/tensorflow/core/kernels/data/BUILD
+++ b/tensorflow/core/kernels/data/BUILD
@@ -708,6 +708,7 @@ tf_kernel_library(
         ":map_and_batch_dataset_op",
         ":map_dataset_op",
         ":map_defun_op",
+        ":matching_files_dataset_op",
         ":optimize_dataset_op",
         ":optional_ops",
         ":padded_batch_dataset_op",
@@ -763,3 +764,17 @@ tf_kernel_library(
         "//tensorflow/core:lib_internal",
     ],
 )
+
+
+tf_kernel_library(
+    name = "matching_files_dataset_op",
+    srcs = ["matching_files_dataset_op.cc"],
+    deps = [
+        ":dataset",
+        "//tensorflow/core:dataset_ops_op_lib",
+        "//tensorflow/core:framework",
+        "//tensorflow/core:lib",
+        "//tensorflow/core:lib_internal",
+    ],
+)
+

--- a/tensorflow/core/kernels/data/matching_files_dataset_op.cc
+++ b/tensorflow/core/kernels/data/matching_files_dataset_op.cc
@@ -1,0 +1,330 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include <queue>
+#include "tensorflow/core/framework/partial_tensor_shape.h"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/kernels/data/dataset.h"
+#include "tensorflow/core/lib/io/buffered_inputstream.h"
+#include "tensorflow/core/lib/io/inputbuffer.h"
+#include "tensorflow/core/lib/io/random_inputstream.h"
+#include "tensorflow/core/lib/io/record_reader.h"
+#include "tensorflow/core/lib/io/zlib_compression_options.h"
+#include "tensorflow/core/lib/io/zlib_inputstream.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/tensor_shape.h"
+#include "tensorflow/core/lib/core/errors.h"
+#include "tensorflow/core/platform/env.h"
+#include "tensorflow/core/lib/io/path.h"
+#include "tensorflow/core/lib/core/threadpool.h"
+
+namespace tensorflow {
+namespace data {
+
+namespace {
+
+constexpr int kNumThreads = 8;
+
+// Run a function in parallel using a ThreadPool, but skip the ThreadPool
+// on the iOS platform due to its problems with more than a few threads.
+void ForEach(int first, int last, const std::function<void(int)>& f) {
+#if TARGET_OS_IPHONE
+  for (int i = first; i < last; i++) {
+    f(i);
+  }
+#else
+  int num_threads = std::min(kNumThreads, last - first);
+  thread::ThreadPool threads(Env::Default(), "ForEach", num_threads);
+  for (int i = first; i < last; i++) {
+    threads.Schedule([f, i] { f(i); });
+  }
+#endif
+}
+
+}  // namespace
+
+namespace {
+
+class MatchingFilesDatasetOp : public DatasetOpKernel {
+ public:
+  using DatasetOpKernel::DatasetOpKernel;
+
+  void MakeDataset(OpKernelContext* ctx, DatasetBase** output) override {
+    const Tensor* patterns_t;
+    // NOTE(originally from ringwalt): Changing the input name "pattern" to
+    // "patterns" would break existing graphs.
+    OP_REQUIRES_OK(ctx, ctx->input("pattern", &patterns_t));
+    OP_REQUIRES(
+        ctx,
+        TensorShapeUtils::IsScalar(patterns_t->shape()) ||
+            TensorShapeUtils::IsVector(patterns_t->shape()),
+        errors::InvalidArgument(
+            "Input patterns tensor must be scalar or vector, but had shape: ",
+            patterns_t->shape().DebugString()));
+    const auto patterns = patterns_t->flat<string>();
+    size_t num_patterns = static_cast<size_t >(patterns.size());
+    std::vector<string> pattern_strs;
+    pattern_strs.reserve(num_patterns);
+
+    for (int i = 0; i < num_patterns; ++i) {
+      pattern_strs.push_back(patterns(i));
+    }
+
+    // keep the elements in the descending order
+    std::sort(pattern_strs.begin(), pattern_strs.end(), std::greater<string>());
+    *output = new Dataset(ctx, std::move(pattern_strs));
+  }
+
+ private:
+  class Dataset : public DatasetBase {
+   public:
+    Dataset(OpKernelContext* ctx, std::vector<string> patterns)
+        : DatasetBase(DatasetContext(ctx)),
+          pattern_(std::move(patterns)) {}
+
+    std::unique_ptr<IteratorBase> MakeIteratorInternal(
+        const string& prefix) const override {
+      return std::unique_ptr<IteratorBase>(
+          new Iterator({this, strings::StrCat(prefix, "::FileName")}));
+    }
+
+    const DataTypeVector& output_dtypes() const override {
+      static DataTypeVector* dtypes = new DataTypeVector({DT_STRING});
+      return *dtypes;
+    }
+
+    const std::vector<PartialTensorShape>& output_shapes() const override {
+      static std::vector<PartialTensorShape>* shapes =
+          new std::vector<PartialTensorShape>({{}});
+      return *shapes;
+    }
+
+    string DebugString() const override {
+      return "MatchingFilesDatasetOp::Dataset";
+    }
+
+   protected:
+    Status AsGraphDefInternal(SerializationContext* ctx,
+                              DatasetGraphDefBuilder* b,
+                              Node** output) const override {
+      Node* pattern = nullptr;
+      TF_RETURN_IF_ERROR(b->AddVector(pattern_, &pattern));
+      TF_RETURN_IF_ERROR(b->AddDataset(this, {pattern}, output));
+      return Status::OK();
+    }
+
+   private:
+    class Iterator : public DatasetIterator<Dataset> {
+     public:
+      explicit Iterator(const Params& params)
+          : DatasetIterator<Dataset>(params) {}
+
+      Status GetNextInternal(IteratorContext* ctx,
+                             std::vector<Tensor>* out_tensors,
+                             bool* end_of_sequence) override {
+        mutex_lock l(mu_);
+        Status ret;
+
+        while (!filepath_queue_.empty() ||
+            current_pattern_index_ < dataset()->pattern_.size()) {
+          // all the elements in the heap will be the matched file name or the
+          // potential directory
+          if (!filepath_queue_.empty()) {
+            string cur_file = filepath_queue_.top();
+            filepath_queue_.pop();
+
+            // we can also use isDectory() here. But IsDirectory call can be
+            // expensive for some FS
+            if (ctx->env()->MatchPath(cur_file, current_pattern_)){
+              Tensor filepath_tensor(ctx->allocator({}), DT_STRING, {});
+              filepath_tensor.scalar<string>()() = cur_file;
+              out_tensors->emplace_back(std::move(filepath_tensor));
+              *end_of_sequence = false;
+              return Status::OK();
+            }
+
+            // in this case, cur_file is a directory. Then create a sub-pattern
+            // to continue the search
+            size_t pos = current_pattern_.find_first_of("*?[\\");
+            size_t len = current_pattern_.size() - pos;
+            string cur_pattern_suffix = current_pattern_.substr(pos, len);
+            string sub_pattern = strings::StrCat(cur_file,
+                                                 "/",
+                                                 cur_pattern_suffix);
+            Status s = UpdateIterator(ctx->env(), sub_pattern);
+            ret.Update(s);
+          } else {
+            // search a new pattern
+            current_pattern_ = dataset()->pattern_[current_pattern_index_];
+            Status s = UpdateIterator(ctx->env(), current_pattern_);
+            ret.Update(s);
+            ++current_pattern_index_;
+          }
+        }
+
+        *end_of_sequence = true;
+        return Status::OK();
+      }
+
+     protected:
+      Status SaveInternal(IteratorStateWriter* writer) override {
+        mutex_lock l(mu_);
+        TF_RETURN_IF_ERROR(writer->WriteScalar(
+            full_name("current_pattern_index"),
+            current_pattern_index_));
+
+        TF_RETURN_IF_ERROR(writer->WriteScalar(
+            full_name("current_pattern"),
+            current_pattern_));
+
+        if (!filepath_queue_.empty()) {
+          TF_RETURN_IF_ERROR(writer->WriteScalar(
+              full_name("queue_size"), filepath_queue_.size()));
+          for (int i = 0; i < filepath_queue_.size(); ++i) {
+            TF_RETURN_IF_ERROR(writer->WriteScalar(
+                full_name(strings::StrCat("queue_element_", i)),
+                filepath_queue_.top()));
+            filepath_queue_.pop();
+          }
+        }
+      }
+
+      Status RestoreInternal(IteratorContext* ctx,
+                             IteratorStateReader* reader) override {
+        mutex_lock l(mu_);
+        int64 current_pattern_index;
+        TF_RETURN_IF_ERROR(reader->ReadScalar(full_name("current_pattern_index"),
+                                              &current_pattern_index));
+        current_pattern_index_ = size_t(current_pattern_index);
+
+        TF_RETURN_IF_ERROR(reader->ReadScalar(full_name("current_pattern"),
+                                              &current_pattern_));
+
+        int64 queue_size;
+        TF_RETURN_IF_ERROR(reader->ReadScalar(full_name("queue_size"),
+                                              &queue_size));
+        for (int i = static_cast<int>(queue_size - 1); i >= 0; --i) {
+          string element;
+          TF_RETURN_IF_ERROR(reader->ReadScalar(
+              full_name(strings::StrCat("queue_element_", i)), &element));
+          filepath_queue_.push(element);
+        }
+        return Status::OK();
+      }
+
+     private:
+      Status UpdateIterator(Env *env, const string &pattern)
+      EXCLUSIVE_LOCKS_REQUIRED(mu_) {
+        string fixed_prefix = pattern.substr(0, pattern.find_first_of("*?[\\"));
+        string eval_pattern = pattern;
+        string dir(io::Dirname(fixed_prefix));
+
+        // If dir is empty then we need to fix up fixed_prefix and eval_pattern to
+        // include . as the top level directory.
+        if (dir.empty()) {
+          dir = ".";
+          fixed_prefix = io::JoinPath(dir, fixed_prefix);
+          eval_pattern = io::JoinPath(dir, pattern);
+        }
+
+        FileSystem* fs;
+        TF_RETURN_IF_ERROR(env->GetFileSystemForFile(dir, &fs));
+
+        filepath_queue_.push(dir);
+        Status ret;  //Status to return
+        // children_dir_status holds is_dir status for children. It can have three
+        // possible values: OK for true; FAILED_PRECONDITION for false; CANCELLED
+        // if we don't calculate IsDirectory (we might do that because there isn't
+        // any point in exploring that child path).
+
+        // DFS to find the first element in the iterator
+        while (!filepath_queue_.empty()) {
+          string cur_dir = filepath_queue_.top();
+          filepath_queue_.pop();
+          std::vector<string> children;
+          Status s = fs->GetChildren(cur_dir, &children);
+          ret.Update(s);
+
+          // if cur_dir has no children, there will two possible situations: 1)
+          // the cur_dir is an empty dir; 2) the cur_dir is actual a file
+          // instead of a director. For the first one, continue to search the
+          // heap; For the second one, if the file matches the pattern, add
+          // it to the heap and finish the search; otherwise, continue the next
+          // search
+          if (children.empty()) {
+            if (env->MatchPath(cur_dir, current_pattern_)) {
+              filepath_queue_.push(cur_dir);
+              return ret;
+            } else {
+              continue;
+            }
+          }
+
+          std::map<string, Status> children_dir_status;
+          // This IsDirectory call can be expensive for some FS. Parallelizing it.
+          ForEach(0, children.size(),
+                  [fs, &cur_dir, &children, &fixed_prefix,
+                      &children_dir_status] (int i) {
+                    const string child_path = io::JoinPath(cur_dir, children[i]);
+                    // In case the child_path doesn't start with the fixed_prefix then
+                    // we don't need to explore this path.
+                    if (!str_util::StartsWith(child_path, fixed_prefix)) {
+                      children_dir_status[child_path] =
+                          Status(tensorflow::error::CANCELLED,
+                                 "Operation not needed");
+                    } else {
+                      children_dir_status[child_path] = fs->IsDirectory(child_path);
+                    }
+                  });
+
+          for (const auto &child : children) {
+            const string child_dir_path = io::JoinPath(cur_dir, child);
+            const Status child_dir_status = children_dir_status[child];
+            // If the IsDirectory call was cancelled we bail.
+            if (child_dir_status.code() == tensorflow::error::CANCELLED) {
+              continue;
+            }
+
+            if (child_dir_status.ok()) {
+              //push the child dir for next search
+              filepath_queue_.push(child_dir_path);
+            } else {
+              // this case will be a file; if the file match the pattern, push
+              // it to the heap; otherwise, ignore it
+              if (env->MatchPath(child_dir_path, eval_pattern)) {
+                filepath_queue_.push(child_dir_path);
+              }
+            }
+          }
+        }
+        return ret;
+      }
+
+      mutex mu_;
+      //std::unique_ptr<std::priority_queue<string>> filepath_queue_ GUARDED_BY(mu_);
+      std::priority_queue<string> filepath_queue_ GUARDED_BY(mu_); // = new std::priority_queue<string>;
+      size_t current_pattern_index_ GUARDED_BY(mu_) = 0;
+      string current_pattern_ GUARDED_BY(mu_);
+    };
+
+    const std::vector<string> pattern_;
+  };
+};
+
+REGISTER_KERNEL_BUILDER(Name("MatchingFilesDataset").Device(DEVICE_CPU),
+                        MatchingFilesDatasetOp);
+
+}  // namespace
+}  // namespace data
+}  // namespace tensorflow

--- a/tensorflow/core/ops/dataset_ops.cc
+++ b/tensorflow/core/ops/dataset_ops.cc
@@ -611,6 +611,18 @@ REGISTER_OP("TextLineDataset")
       return shape_inference::ScalarShape(c);
     });
 
+REGISTER_OP("MatchingFilesDataset")
+    .Input("pattern: string")
+    .Output("handle: variant")
+    .SetIsStateful()  // TODO(b/65524810): Source dataset ops must be marked
+        // stateful to inhibit constant folding.
+    .SetShapeFn([](shape_inference::InferenceContext* c) {
+      shape_inference::ShapeHandle unused;
+      // `patterns` must be a scalar or a vector.
+      TF_RETURN_IF_ERROR(c->WithRankAtMost(c->input(0), 1, &unused));
+      return shape_inference::ScalarShape(c);
+    });
+
 REGISTER_OP("SqlDataset")
     .Input("driver_name: string")
     .Input("data_source_name: string")

--- a/tensorflow/python/data/kernel_tests/BUILD
+++ b/tensorflow/python/data/kernel_tests/BUILD
@@ -178,6 +178,28 @@ tf_py_test(
 )
 
 tf_py_test(
+    name = "matching_files_dataset_op_test",
+    size = "small",
+    srcs = ["matching_files_dataset_op_test.py"],
+    additional_deps = [
+        "//tensorflow/python:array_ops",
+        "//tensorflow/python:client_testlib",
+        "//tensorflow/python:constant_op",
+        "//tensorflow/python:dataset_ops_gen",
+        "//tensorflow/python:dtypes",
+        "//tensorflow/python:errors",
+        "//tensorflow/python:framework_ops",
+        "//tensorflow/python:io_ops",
+        "//tensorflow/python:lib",
+        "//tensorflow/python:parsing_ops",
+        "//tensorflow/python:tensor_shape",
+        "//tensorflow/python:util",
+        "//tensorflow/python/data/ops:iterator_ops",
+        "//tensorflow/python/data/ops:readers",
+    ],
+)
+
+tf_py_test(
     name = "prefetch_dataset_op_test",
     size = "small",
     srcs = ["prefetch_dataset_op_test.py"],

--- a/tensorflow/python/data/kernel_tests/matching_files_dataset_op_test.py
+++ b/tensorflow/python/data/kernel_tests/matching_files_dataset_op_test.py
@@ -56,8 +56,8 @@ def timeit(fn, msg, N=0):
   return res
 
 
-width = 10
-depth = 2
+width = 1000
+depth = 20
 
 
 class MatchingFilesDatasetTest(test.TestCase):
@@ -219,7 +219,9 @@ class MatchingFilesDatasetTest(test.TestCase):
     get_next = iterator.get_next()
     result = []
     with self.cached_session() as sess:
-      search_patterns = [base + "/*/*/*.txt"]
+      pattern = '{}/{}/*.txt'\
+        .format(base, os.path.join(*['**' for _ in range(depth)]))
+      search_patterns = [pattern]
       sess.run(init_op, feed_dict={patterns: search_patterns})
       result.extend(timeit(partial(self._read_data_with_result, get_next, sess),
         "read first filename"))
@@ -231,8 +233,6 @@ class MatchingFilesDatasetTest(test.TestCase):
       result.extend(filename)
 
     matched_filenames = [compat.as_bytes(x) for x in result]
-    for file in matched_filenames:
-      print(file)
     self.assertItemsEqual(matched_filenames, test_filenames)
 
 

--- a/tensorflow/python/data/kernel_tests/matching_files_dataset_op_test.py
+++ b/tensorflow/python/data/kernel_tests/matching_files_dataset_op_test.py
@@ -1,0 +1,240 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for the experimental input pipeline ops."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from os import path
+import shutil
+import tempfile
+
+from tensorflow.python.data.ops import iterator_ops
+from tensorflow.python.data.ops.dataset_ops import MatchingFilesDataset
+from tensorflow.python.framework import dtypes
+from tensorflow.python.ops import array_ops
+from tensorflow.python.platform import test
+from tensorflow.python.util import compat
+from tensorflow.python.data.ops import dataset_ops
+from tensorflow.python.ops.gen_io_ops import matching_files
+from tensorflow.python.framework import errors
+
+import os
+import time
+from functools import partial
+
+
+try:
+  import psutil  # pylint: disable=g-import-not-at-top
+
+  psutil_import_succeeded = True
+except ImportError:
+  psutil_import_succeeded = False
+
+
+def timeit(fn, msg, N=0):
+  start = time.time()
+  res = fn()
+  end = time.time()
+  runtime = (end - start) * 1000
+  msg = '{}: time: {:.2f} ms'.format(msg, runtime)
+  if N:
+    msg += ' ({:.2f} ms per iteration)'.format(runtime / N)
+  print(msg)
+  return res
+
+
+width = 10
+depth = 2
+
+
+class MatchingFilesDatasetTest(test.TestCase):
+
+  def setUp(self):
+    self.tmp_dir = tempfile.mkdtemp()
+
+  def tearDown(self):
+    shutil.rmtree(self.tmp_dir, ignore_errors=True)
+
+  def _touchTempFiles(self, filenames):
+    for filename in filenames:
+      open(path.join(self.tmp_dir, filename), 'a').close()
+
+  def testEmptyDirectory(self):
+    dataset = MatchingFilesDataset(path.join(self.tmp_dir, '*'))
+    with self.cached_session() as sess:
+      itr = iterator_ops.Iterator.from_structure(dataset.output_types)
+      init_op = itr.make_initializer(dataset)
+      next_element = itr.get_next()
+      sess.run(init_op)
+      with self.assertRaises(errors.OutOfRangeError):
+        sess.run(next_element)
+
+  def testSimpleDirectory(self):
+    filenames = ['a', 'b', 'c']
+    self._touchTempFiles(filenames)
+
+    dataset = MatchingFilesDataset(path.join(self.tmp_dir, '*'))
+    with self.cached_session() as sess:
+      itr = iterator_ops.Iterator.from_structure(dataset.output_types)
+      init_op = itr.make_initializer(dataset)
+      next_element = itr.get_next()
+      sess.run(init_op)
+
+      full_filenames = []
+      produced_filenames = []
+      for filename in filenames:
+        full_filenames.append(
+          compat.as_bytes(path.join(self.tmp_dir, filename)))
+        produced_filenames.append(compat.as_bytes(sess.run(next_element)))
+      self.assertItemsEqual(full_filenames, produced_filenames)
+      with self.assertRaises(errors.OutOfRangeError):
+        sess.run(itr.get_next())
+
+  def testSimpleDirectoryInitializer(self):
+    filenames = ['a', 'b', 'c']
+    self._touchTempFiles(filenames)
+
+    filename_placeholder = array_ops.placeholder(dtypes.string, shape=[])
+    dataset = MatchingFilesDataset(filename_placeholder)
+
+    with self.cached_session() as sess:
+      itr = iterator_ops.Iterator.from_structure(dataset.output_types)
+      init_op = itr.make_initializer(dataset)
+      next_element = itr.get_next()
+      sess.run(
+        init_op,
+        feed_dict={filename_placeholder: path.join(self.tmp_dir, '*')})
+
+      full_filenames = []
+      produced_filenames = []
+      for filename in filenames:
+        full_filenames.append(
+          compat.as_bytes(path.join(self.tmp_dir, filename)))
+        produced_filenames.append(compat.as_bytes(sess.run(next_element)))
+
+      self.assertItemsEqual(full_filenames, produced_filenames)
+
+      with self.assertRaises(errors.OutOfRangeError):
+        sess.run(itr.get_next())
+
+  def testFileSuffixes(self):
+    filenames = ['a.txt', 'b.py', 'c.py', 'd.pyc']
+    self._touchTempFiles(filenames)
+
+    filename_placeholder = array_ops.placeholder(dtypes.string, shape=[])
+    dataset = MatchingFilesDataset(filename_placeholder)
+
+    with self.cached_session() as sess:
+      itr = iterator_ops.Iterator.from_structure(dataset.output_types)
+      init_op = itr.make_initializer(dataset)
+      next_element = itr.get_next()
+      sess.run(
+        init_op,
+        feed_dict={filename_placeholder: path.join(self.tmp_dir, '*.py')})
+
+      full_filenames = []
+      produced_filenames = []
+      for filename in filenames[1:-1]:
+        full_filenames.append(
+          compat.as_bytes(path.join(self.tmp_dir, filename)))
+        produced_filenames.append(compat.as_bytes(sess.run(next_element)))
+      self.assertItemsEqual(full_filenames, produced_filenames)
+
+      with self.assertRaises(errors.OutOfRangeError):
+        sess.run(itr.get_next())
+
+  def testFileMiddles(self):
+    filenames = ['a.txt', 'b.py', 'c.pyc']
+    self._touchTempFiles(filenames)
+
+    filename_placeholder = array_ops.placeholder(dtypes.string, shape=[])
+    dataset = MatchingFilesDataset(filename_placeholder)
+
+    with self.cached_session() as sess:
+      itr = iterator_ops.Iterator.from_structure(dataset.output_types)
+      init_op = itr.make_initializer(dataset)
+      next_element = itr.get_next()
+      sess.run(
+        init_op,
+        feed_dict={filename_placeholder: path.join(self.tmp_dir, '*.py*')})
+
+      full_filenames = []
+      produced_filenames = []
+      for filename in filenames[1:]:
+        full_filenames.append(
+          compat.as_bytes(path.join(self.tmp_dir, filename)))
+        produced_filenames.append(compat.as_bytes(sess.run(next_element)))
+
+      self.assertItemsEqual(full_filenames, produced_filenames)
+
+      with self.assertRaises(errors.OutOfRangeError):
+        sess.run(itr.get_next())
+
+  def _load_data(self):
+    new_files = []
+    dir = "/tmp/test/"
+    if not os.path.exists(dir):
+      os.makedirs(dir)
+    base = tempfile.mkdtemp(prefix=dir)
+    print('saving files to dir: {}'.format(base))
+    for i in range(width):
+      new_base = os.path.join(base, str(i), *[str(j) for j in range(depth - 1)])
+      if not os.path.exists(new_base):
+        os.makedirs(new_base)
+      f = os.path.join(new_base, 'stuff.txt')
+      new_files.append(compat.as_bytes(f))
+      open(f, 'w').close()
+    return base, new_files
+
+  def _read_data(self, data, sess, N=1):
+    for _ in range(N):
+      sess.run(data)
+
+  def _read_data_with_result(self, data, sess, N=1):
+    result = []
+    for _ in range(N):
+      result.append(sess.run(data))
+    return result
+
+  def testPerformance(self):
+    base, test_filenames = self._load_data()
+    test_filenames.sort(reverse=True)
+    patterns = array_ops.placeholder(dtypes.string, shape=[None])
+    dataset = MatchingFilesDataset(patterns)
+    iterator = iterator_ops.Iterator.from_structure(dataset.output_types)
+    init_op = iterator.make_initializer(dataset)
+    get_next = iterator.get_next()
+    result = []
+    with self.cached_session() as sess:
+      search_patterns = [base + "/*/*/*.txt"]
+      sess.run(init_op, feed_dict={patterns: search_patterns})
+      result.extend(timeit(partial(self._read_data_with_result, get_next, sess),
+        "read first filename"))
+      result.extend(timeit(partial(self._read_data_with_result, get_next, sess),
+        "read second filename"))
+      N = width * len(search_patterns) - 2
+      filename = timeit(partial(self._read_data_with_result, get_next, sess, N),
+        'read {} more filenames'.format(N), N)
+      result.extend(filename)
+
+    matched_filenames = [compat.as_bytes(x) for x in result]
+    for file in matched_filenames:
+      print(file)
+    self.assertItemsEqual(matched_filenames, test_filenames)
+
+
+if __name__ == "__main__":
+  test.main()

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -2216,6 +2216,30 @@ def _warn_if_collections(transformation_name):
                   % transformation_name)
 
 
+class MatchingFilesDataset(Dataset):
+  """A `Dataset` that list the files according to the input patterns"""
+
+  def __init__(self, pattern):
+    super(MatchingFilesDataset, self).__init__()
+    self._pattern = ops.convert_to_tensor(
+      pattern, dtype=dtypes.string, name="pattern")
+
+
+  def _as_variant_tensor(self):
+    return gen_dataset_ops.matching_files_dataset(self._pattern)
+
+  @property
+  def output_classes(self):
+    return ops.Tensor
+
+  @property
+  def output_shapes(self):
+    return tensor_shape.scalar()
+
+  @property
+  def output_types(self):
+    return dtypes.string
+
 class MapDataset(Dataset):
   """A `Dataset` that maps a function over elements in its input."""
 


### PR DESCRIPTION
This PR aims to add `MatchingFilesDatasetOp` to improve the performance of [Dataset.list_files](https://www.tensorflow.org/api_docs/python/tf/data/Dataset#list_files), which needs to scan the entire directory tree and load the filenames into memory before the next operation starts. More details can be found at (https://github.com/tensorflow/tensorflow/issues/17810). 

`MatchingFilesDatasetOp` could yield the matching files in a sorted order. 

The initial performance test is in below , where `width` is the number of dirs at each level, and `depth` is the number of nested dirs.

- when `width = 1000` and `depth = 2`:

-- `MatchingFilesDataset`:
```
read first filename: time: 16.06 ms
read second filename: time: 0.52 ms
read 998 more filenames: time: 336.51 ms (0.34 ms per iteration)
```
-- `Dataset.list_files()`:
```
read first filename: time: 253.91 ms
read second filename: time: 0.27 ms
read 998 more filenames: time: 135.77 ms (0.14 ms per iteration)
```

 - when `width = 1000` and `depth = 20`:

-- `MatchingFilesDataset`:
```
read first filename: time: 22.16 ms
read second filename: time: 3.09 ms
read 998 more filenames: time: 2269.14 ms (2.27 ms per iteration)
```

-- `Dataset.list_files()`:
```
read first filename: time: 1860.96 ms
read second filename: time: 0.38 ms
read 998 more filenames: time: 127.23 ms (0.13 ms per iteration)
```

The performance test-related functions (e.g., `testPerformance`) in `tensorflow/python/data/kernel_tests/matching_files_dataset_op_test.py` will be removed later.