### PR TITLE
Develop C++ infrastructure for testing tf.data kernel implementations in C++

### DIFF
--- a/tensorflow/core/grappler/grappler_item_builder.cc
+++ b/tensorflow/core/grappler/grappler_item_builder.cc
@@ -103,7 +103,11 @@ Status OptimizeGraph(const GraphDef& graph_def_arg, GraphDef* output_graph_def,
 
   // Instantiate all variables for function library runtime creation.
   std::vector<std::unique_ptr<Device>> devices;
-  TF_RETURN_IF_ERROR(DeviceFactory::AddDevices(
+  // Only CPU device is used so instead of calling DeviceFactory::AddDevices()
+  // with dummy session config, which will conflict with user defined options and
+  // create unwanted devices, call cpu_factory->CreateDevices() to get CPU only devices.
+  DeviceFactory* cpu_factory = DeviceFactory::GetFactory("CPU");
+  TF_RETURN_IF_ERROR(cpu_factory->CreateDevices(
       options, "/job:localhost/replica:0/task:0", &devices));
   Device* cpu_device = devices[0].get();
   std::unique_ptr<DeviceMgr> dvc_mgr(new DeviceMgr(std::move(devices)));

--- a/tensorflow/core/grappler/grappler_item_builder.cc
+++ b/tensorflow/core/grappler/grappler_item_builder.cc
@@ -104,8 +104,9 @@ Status OptimizeGraph(const GraphDef& graph_def_arg, GraphDef* output_graph_def,
   // Instantiate all variables for function library runtime creation.
   std::vector<std::unique_ptr<Device>> devices;
   // Only CPU device is used so instead of calling DeviceFactory::AddDevices()
-  // with dummy session config, which will conflict with user defined options and
-  // create unwanted devices, call cpu_factory->CreateDevices() to get CPU only devices.
+  // with dummy session config, which will conflict with user defined options
+  // and create unwanted devices, call cpu_factory->CreateDevices() to get CPU
+  // only devices.
   DeviceFactory* cpu_factory = DeviceFactory::GetFactory("CPU");
   TF_RETURN_IF_ERROR(cpu_factory->CreateDevices(
       options, "/job:localhost/replica:0/task:0", &devices));

--- a/tensorflow/core/kernels/data/BUILD
+++ b/tensorflow/core/kernels/data/BUILD
@@ -39,6 +39,7 @@ tf_cc_test(
     srcs = ["dataset_utils_test.cc"],
     deps = [
         ":dataset_utils",
+        "//tensorflow/core:framework",
         "//tensorflow/core:test",
         "//tensorflow/core:test_main",
     ],

--- a/tensorflow/core/kernels/data/BUILD
+++ b/tensorflow/core/kernels/data/BUILD
@@ -349,8 +349,11 @@ tf_cc_test(
     size = "small",
     srcs = ["range_dataset_op_test.cc"],
     deps = [
+        ":range_dataset_op",
         ":iterator_ops",
         "//tensorflow/core:testlib",
+        "//tensorflow/core:test_main",
+
     ],
 )
 

--- a/tensorflow/core/kernels/data/BUILD
+++ b/tensorflow/core/kernels/data/BUILD
@@ -344,6 +344,16 @@ tf_kernel_library(
     ],
 )
 
+tf_cc_test(
+    name = "range_dataset_op_test",
+    size = "small",
+    srcs = ["range_dataset_op_test.cc"],
+    deps = [
+        ":iterator_ops",
+        "//tensorflow/core:testlib",
+    ],
+)
+
 tf_kernel_library(
     name = "shuffle_dataset_op",
     srcs = ["shuffle_dataset_op.cc"],

--- a/tensorflow/core/kernels/data/dataset_utils.cc
+++ b/tensorflow/core/kernels/data/dataset_utils.cc
@@ -168,7 +168,12 @@ void VariantTensorDataReader::PreProcess() {
     return;
   }
   size_t num_entries = proto.keys_size();
-  CHECK_EQ(num_entries, data_->tensors_size());
+  if (num_entries != data_->tensors_size()) {
+    status_ = errors::InvalidArgument("Unmatched number of keys and tensors: ",
+                                      num_entries, " vs. ",
+                                      data_->tensors_size());
+    return;
+  }
   for (size_t i = 0; i < num_entries; i++) {
     map_[proto.keys(i)] = i;
   }

--- a/tensorflow/core/kernels/data/dataset_utils.cc
+++ b/tensorflow/core/kernels/data/dataset_utils.cc
@@ -169,9 +169,9 @@ void VariantTensorDataReader::PreProcess() {
   }
   size_t num_entries = proto.keys_size();
   if (num_entries != data_->tensors_size()) {
-    status_ = errors::InvalidArgument("Unmatched number of keys and tensors: ",
-                                      num_entries, " vs. ",
-                                      data_->tensors_size());
+    status_ = errors::InvalidArgument(
+        "Unmatched number of keys and tensors: ", num_entries, " vs. ",
+        data_->tensors_size());
     return;
   }
   for (size_t i = 0; i < num_entries; i++) {

--- a/tensorflow/core/kernels/data/dataset_utils.cc
+++ b/tensorflow/core/kernels/data/dataset_utils.cc
@@ -169,9 +169,9 @@ void VariantTensorDataReader::PreProcess() {
   }
   size_t num_entries = proto.keys_size();
   if (num_entries != data_->tensors_size()) {
-    status_ = errors::InvalidArgument(
-        "Unmatched number of keys and tensors: ", num_entries, " vs. ",
-        data_->tensors_size());
+    status_ =
+        errors::InvalidArgument("Unmatched number of keys and tensors: ",
+                                num_entries, " vs. ", data_->tensors_size());
     return;
   }
   for (size_t i = 0; i < num_entries; i++) {

--- a/tensorflow/core/kernels/data/dataset_utils_test.cc
+++ b/tensorflow/core/kernels/data/dataset_utils_test.cc
@@ -75,10 +75,17 @@ TEST(DatasetUtilsTest, VariantTensorData_Writer_Reader) {
   EXPECT_EQ(error::NOT_FOUND,
             reader.ReadTensor("Non_Existing_Key", &val_tensor).code());
 
-  // Test the invalid parameter for the constructor of VariantTensorDataReader.
-  data.metadata_ = "Invalid Metadata";
-  VariantTensorDataReader reader2(&data);
+  // Test the invalid metadata for VariantTensorDataReader.
+  VariantTensorData data_invalid_meta(data);
+  data_invalid_meta.metadata_ = "Invalid Metadata";
+  VariantTensorDataReader reader2(&data_invalid_meta);
   EXPECT_EQ(error::INTERNAL, reader2.status().code());
+
+  // Test the unmatched number of keys and tensors for VariantTensorDataReader.
+  VariantTensorData data_unmatched_entries(data);
+  data_unmatched_entries.tensors_.push_back(Tensor(DT_INT64, {1}));
+  VariantTensorDataReader reader3(&data_unmatched_entries);
+  EXPECT_EQ(error::INVALID_ARGUMENT, reader3.status().code());
 }
 
 }  // namespace

--- a/tensorflow/core/kernels/data/dataset_utils_test.cc
+++ b/tensorflow/core/kernels/data/dataset_utils_test.cc
@@ -13,15 +13,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include "tensorflow/core/framework/variant.h"
 #include "tensorflow/core/kernels/data/dataset_utils.h"
-
+#include "tensorflow/core/lib/core/status_test_util.h"
 #include "tensorflow/core/platform/test.h"
 
 namespace tensorflow {
 namespace data {
 namespace {
 
-TEST(DatasetUtils, ComputeMoveVector) {
+TEST(DatasetUtilsTest, ComputeMoveVector) {
   struct TestCase {
     std::vector<int> indices;
     std::vector<bool> expected;
@@ -39,6 +40,45 @@ TEST(DatasetUtils, ComputeMoveVector) {
   for (auto& test_case : test_cases) {
     EXPECT_EQ(test_case.expected, ComputeMoveVector(test_case.indices));
   }
+}
+
+TEST(DatasetUtilsTest, VariantTensorData_Writer_Reader) {
+  VariantTensorData data;
+
+  // Basic test cases.
+  VariantTensorDataWriter writer(&data);
+  TF_ASSERT_OK(writer.WriteScalar("Int64", 24));
+  TF_ASSERT_OK(writer.WriteScalar("", "Empty_Key"));
+  Tensor input_tensor(DT_FLOAT, {1});
+  input_tensor.flat<float>()(0) = 2.0f;
+  TF_ASSERT_OK(writer.WriteTensor("Tensor", input_tensor));
+  TF_ASSERT_OK(writer.Flush());
+
+  VariantTensorDataReader reader(&data);
+  EXPECT_OK(reader.status());
+  int64 val_int64;
+  TF_ASSERT_OK(reader.ReadScalar("Int64", &val_int64));
+  EXPECT_EQ(val_int64, 24);
+  string val_string;
+  TF_ASSERT_OK(reader.ReadScalar("", &val_string));
+  EXPECT_EQ(val_string, "Empty_Key");
+  Tensor val_tensor;
+  TF_ASSERT_OK(reader.ReadTensor("Tensor", &val_tensor));
+  EXPECT_EQ(input_tensor.NumElements(), val_tensor.NumElements());
+  EXPECT_EQ(input_tensor.flat<float>()(0), val_tensor.flat<float>()(0));
+
+  // Test the non-existing key for VariantTensorDataReader.
+  EXPECT_EQ(error::NOT_FOUND,
+            reader.ReadScalar("Non_Existing_Key", &val_int64).code());
+  EXPECT_EQ(error::NOT_FOUND,
+            reader.ReadScalar("Non_Existing_Key", &val_string).code());
+  EXPECT_EQ(error::NOT_FOUND,
+            reader.ReadTensor("Non_Existing_Key", &val_tensor).code());
+
+  // Test the invalid parameter for the constructor of VariantTensorDataReader.
+  data.metadata_ = "Invalid Metadata";
+  VariantTensorDataReader reader2(&data);
+  EXPECT_EQ(error::INTERNAL, reader2.status().code());
 }
 
 }  // namespace

--- a/tensorflow/core/kernels/data/iterator_ops.cc
+++ b/tensorflow/core/kernels/data/iterator_ops.cc
@@ -20,7 +20,6 @@ limitations under the License.
 #include "tensorflow/core/common_runtime/threadpool_device.h"
 #include "tensorflow/core/framework/function.h"
 #include "tensorflow/core/framework/function_handle_cache.h"
-#include "tensorflow/core/framework/iterator.pb.h"
 #include "tensorflow/core/framework/partial_tensor_shape.h"
 #include "tensorflow/core/framework/resource_op_kernel.h"
 #include "tensorflow/core/framework/stats_aggregator.h"
@@ -277,124 +276,6 @@ class IteratorResource : public ResourceBase {
 };
 
 namespace {
-
-// Helper class for reading data from a VariantTensorData object.
-class VariantTensorDataReader : public IteratorStateReader {
- public:
-  explicit VariantTensorDataReader(const VariantTensorData* data)
-      : data_(data) {
-    PreProcess();
-  }
-
-  // Returns OK iff the initialization was successful, i.e.,
-  // pre-processing did not have errors.
-  Status status() const { return status_; }
-
-  Status ReadScalar(StringPiece key, int64* val) override {
-    return ReadScalarInternal(key, val);
-  }
-
-  Status ReadScalar(StringPiece key, string* val) override {
-    return ReadScalarInternal(key, val);
-  }
-
-  Status ReadTensor(StringPiece key, Tensor* val) override {
-    return ReadTensorInternal(key, val);
-  }
-
-  bool Contains(StringPiece key) override {
-    return map_.find(string(key)) != map_.end();
-  }
-
- private:
-  void PreProcess() {
-    string metadata;
-    data_->get_metadata(&metadata);
-    IteratorStateMetadata proto;
-    if (!proto.ParseFromString(metadata)) {
-      status_ = errors::Internal("Error parsing IteratorStateMetadata.");
-      return;
-    }
-    size_t num_entries = proto.keys_size();
-    CHECK_EQ(num_entries, data_->tensors_size());
-    for (size_t i = 0; i < num_entries; i++) {
-      map_[proto.keys(i)] = i;
-    }
-  }
-
-  template <typename T>
-  Status ReadScalarInternal(StringPiece key, T* val) {
-    if (map_.find(string(key)) == map_.end()) {
-      return errors::NotFound(key);
-    }
-    *val = data_->tensors(map_[string(key)]).scalar<T>()();
-    return Status::OK();
-  }
-
-  Status ReadTensorInternal(StringPiece key, Tensor* val) {
-    if (map_.find(string(key)) == map_.end()) {
-      return errors::NotFound(key);
-    }
-    *val = data_->tensors(map_[string(key)]);
-    return Status::OK();
-  }
-
-  std::map<string, size_t> map_;
-  const VariantTensorData* data_;  // Not owned.
-  Status status_;
-};
-
-// Helper class for writing data to a VariantTensorData object.
-class VariantTensorDataWriter : public IteratorStateWriter {
- public:
-  // Does not take ownership of data.
-  explicit VariantTensorDataWriter(VariantTensorData* data) : data_(data) {}
-
-  Status WriteScalar(StringPiece key, const int64 val) override {
-    return WriteScalarInternal(key, val);
-  }
-
-  Status WriteScalar(StringPiece key, const string& val) override {
-    return WriteScalarInternal(key, val);
-  }
-
-  Status WriteTensor(StringPiece key, const Tensor& val) override {
-    return WriteTensorInternal(key, val);
-  }
-
-  // Writes the metadata to `data_`.
-  Status Flush() {
-    string metadata;
-    if (!metadata_proto_.SerializeToString(&metadata)) {
-      return errors::Internal("Unable to serialize IteratorStateMetadata.");
-    }
-    data_->set_metadata(metadata);
-    return Status::OK();
-  }
-
- private:
-  template <typename T>
-  Status WriteScalarInternal(StringPiece key, const T& val) {
-    Tensor val_t = Tensor(DataTypeToEnum<T>::v(), TensorShape({}));
-    val_t.scalar<T>()() = val;
-    return WriteTensorInternal(key, val_t);
-  }
-
-  Status WriteTensorInternal(StringPiece key, const Tensor& val) {
-    // Write key to the metadata proto. This gets written to `data_`
-    // when `Flush()` is called. We do this lazily to avoid multiple
-    // serialization calls.
-    metadata_proto_.add_keys(string(key));
-
-    // Update tensors.
-    *(data_->add_tensors()) = val;
-    return Status::OK();
-  }
-
-  VariantTensorData* data_;
-  // TODO(srbs): Set the version string.
-  IteratorStateMetadata metadata_proto_;
-};
 
 // Wrapper for encoding/decoding the iterator state stored in a Variant tensor.
 // The get() method returns an IteratorStateReader which can be used

--- a/tensorflow/core/kernels/data/range_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/range_dataset_op_test.cc
@@ -28,6 +28,22 @@ namespace {
 
 class RangeDatasetOpTest : public OpsTestBase {
  public:
+  ~RangeDatasetOpTest() override {
+    gtl::STLDeleteElements(&tensors_);
+    gtl::STLDeleteElements(&managed_outputs_);
+    context_.reset(nullptr);
+    params_.reset(nullptr);
+    device_mgr_.reset(nullptr);
+    delete flr_;
+    lib_def_.reset(nullptr);
+    pflr_.reset(nullptr);
+    delete &fdef_lib_;
+    delete thread_pool_;
+    delete &runner_;
+    delete dataset_;
+    delete iteratorContext_;
+    iterator_.reset(nullptr);
+  }
   Status InitOp() { return InitOpWithGraphVersion(TF_GRAPH_DEF_VERSION); }
 
   // Only use this directly if you have a deprecated op that you need to test.

--- a/tensorflow/core/kernels/data/range_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/range_dataset_op_test.cc
@@ -35,13 +35,11 @@ class RangeDatasetOpTest : public OpsTestBase {
     dataset_->Unref();
   }
 
-  Status InitOp() { return InitOpWithGraphVersion(TF_GRAPH_DEF_VERSION); }
-
-  // Only use this directly if you have a deprecated op that you need to test.
-  inline Status InitOpWithGraphVersion(int graph_def_version) {
+  Status InitOp() {
     Status status;
     kernel_ = CreateOpKernel(device_type_, device_.get(), allocator(),
-                             node_def_, graph_def_version, &status);
+                             node_def_, TF_GRAPH_DEF_VERSION, &status);
+    TF_RETURN_IF_ERROR(status);
     if (kernel_ != nullptr) input_types_ = kernel_->input_types();
     return status;
   }
@@ -170,8 +168,7 @@ class RangeDatasetOpTest : public OpsTestBase {
 
  protected:
   DatasetBase* dataset_;
-  // not owned
-  FunctionLibraryRuntime* flr_;
+  FunctionLibraryRuntime* flr_; // not owned
   std::function<void(std::function<void()>)> runner_;
   std::unique_ptr<DeviceMgr> device_mgr_;
   std::unique_ptr<FunctionLibraryDefinition> lib_def_;

--- a/tensorflow/core/kernels/data/range_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/range_dataset_op_test.cc
@@ -32,6 +32,9 @@ namespace {
 
 class RangeDatasetOpTest : public OpsTestBase {
  public:
+  static const char* kNodeName;
+  static const char* kOpName;
+
   ~RangeDatasetOpTest() override {
     gtl::STLDeleteElements(&tensors_);
     gtl::STLDeleteElements(&managed_outputs_);
@@ -191,12 +194,10 @@ class RangeDatasetOpTest : public OpsTestBase {
   std::unique_ptr<IteratorContext> iterator_context_;
   std::unique_ptr<IteratorBase> iterator_;
   std::unique_ptr<SerializationContext> serialization_context_;
-  static const string kNodeName;
-  static const string kOpName;
 };
 
-const string RangeDatasetOpTest::kNodeName = "range_dataset";
-const string RangeDatasetOpTest::kOpName = "RangeDataset";
+const char* RangeDatasetOpTest::kNodeName = "range_dataset";
+const char* RangeDatasetOpTest::kOpName = "RangeDataset";
 
 struct DatasetGetNextTest
     : RangeDatasetOpTest,

--- a/tensorflow/core/kernels/data/range_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/range_dataset_op_test.cc
@@ -1,0 +1,207 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/framework/dataset.h"
+#include "tensorflow/core/framework/fake_input.h"
+#include "tensorflow/core/framework/node_def_builder.h"
+#include "tensorflow/core/framework/partial_tensor_shape.h"
+#include "tensorflow/core/framework/variant.h"
+#include "tensorflow/core/kernels/data/iterator_ops.h"
+#include "tensorflow/core/kernels/ops_testutil.h"
+#include "tensorflow/core/platform/test.h"
+
+namespace tensorflow {
+namespace data {
+namespace {
+
+class RangeDatasetOpTest : public OpsTestBase {
+ public:
+  Status InitOp() { return InitOpWithGraphVersion(TF_GRAPH_DEF_VERSION); }
+
+  // Only use this directly if you have a deprecated op that you need to test.
+  Status InitOpWithGraphVersion(int graph_def_version) {
+    OpKernel* kernel = nullptr;
+    Status status = CreateOpKernel(device_type_, device_.get(), allocator(),
+                                   flr_, node_def_, graph_def_version, &kernel);
+    kernel_.reset(kernel);
+    if (kernel_ != nullptr) input_types_ = kernel_->input_types();
+    return status;
+  }
+
+  Status InitThreadPool(int thread_num = 1) {
+    CHECK_GE(thread_num, 1);
+    thread_pool_ = new thread::ThreadPool(Env::Default(), ThreadOptions(),
+                                          "inter_op", thread_num);
+    return Status::OK();
+  }
+
+  Status InitFunctionLibraryRuntime(const std::vector<FunctionDef>& flib,
+                                    thread::ThreadPool* thread_pool = nullptr,
+                                    int cpu_num = 2) {
+    SessionOptions options;
+    auto* device_count = options.config.mutable_device_count();
+    device_count->insert({"CPU", cpu_num});
+    std::vector<std::unique_ptr<Device>> devices;
+    TF_CHECK_OK(DeviceFactory::AddDevices(
+        options, "/job:localhost/replica:0/task:0", &devices));
+    device_mgr_ = absl::make_unique<DeviceMgr>(std::move(devices));
+
+    FunctionDefLibrary proto;
+    for (const auto& fdef : flib) *(proto.add_function()) = fdef;
+    lib_def_.reset(new FunctionLibraryDefinition(OpRegistry::Global(), proto));
+    fdef_lib_ = lib_def_->ToProto();
+
+    OptimizerOptions opts;
+    pflr_.reset(new ProcessFunctionLibraryRuntime(
+        device_mgr_.get(), Env::Default(), TF_GRAPH_DEF_VERSION, lib_def_.get(),
+        opts, thread_pool, nullptr /* cluster_flr */));
+
+    flr_ = pflr_->GetFLR("/job:localhost/replica:0/task:0/cpu:0");
+
+    if (thread_pool == nullptr) {
+      runner_ = [](std::function<void()> fn) { fn(); };
+    } else {
+      runner_ = [thread_pool](std::function<void()> fn) {
+        thread_pool->Schedule(std::move(fn));
+      };
+    }
+
+    return Status::OK();
+  }
+
+  Status GetDatasetOutputFromContext(int output_index) {
+    auto* tensor = GetOutput(output_index);
+    TF_CHECK_OK(GetDatasetFromVariantTensor(*tensor, &dataset_));
+    return Status::OK();
+  }
+
+  Status RunOpKernel() {
+    // Make sure the old OpKernelContext is deleted before the Params it was
+    // using.
+    context_.reset(nullptr);
+    params_.reset(new OpKernelContext::Params);
+    params_.get()->device = device_.get();
+    params_.get()->frame_iter = FrameAndIter(0, 0);
+    params_.get()->inputs = &inputs_;
+    params_.get()->op_kernel = kernel_.get();
+    params_.get()->function_library = flr_;
+    params_.get()->runner = &runner_;
+
+    step_container_.reset(new ScopedStepContainer(0, [](const string&) {}));
+    params_->step_container = step_container_.get();
+    std::vector<AllocatorAttributes> attrs;
+    test::SetOutputAttrs(params_.get(), &attrs);
+    checkpoint::TensorSliceReaderCacheWrapper slice_reader_cache_wrapper;
+    params_.get()->slice_reader_cache = &slice_reader_cache_wrapper;
+    params_.get()->resource_manager = device_.get()->resource_manager();
+
+    context_.reset(new OpKernelContext(params_.get()));
+    device_->Compute(kernel_.get(), context_.get());
+    return context_->status();
+  }
+
+ protected:
+  template <typename T>
+  void MakeOpDef() {
+    DataType value_type = tensorflow::DataTypeToEnum<T>::value;
+    std::vector<PartialTensorShape>* shapes =
+        new std::vector<PartialTensorShape>({{}});
+    DataTypeVector* dtypes = new DataTypeVector({value_type});
+
+    TF_CHECK_OK(NodeDefBuilder("rangedataset", "RangeDataset")
+                    .Input(FakeInput(DT_INT64))
+                    .Input(FakeInput(DT_INT64))
+                    .Input(FakeInput(DT_INT64))
+                    .Attr("output_types", *dtypes)
+                    .Attr("output_shapes", *shapes)
+                    .Finalize(node_def()));
+    TF_ASSERT_OK(InitOp());
+  }
+
+  Status MakeDataset(int64 start, int64 end, int64 step, int output_index = 0,
+                     int thread_num = 2) {
+    AddInputFromArray<int64>(TensorShape({}), {start});
+    AddInputFromArray<int64>(TensorShape({}), {end});
+    AddInputFromArray<int64>(TensorShape({}), {step});
+
+    TF_CHECK_OK(InitThreadPool(thread_num));
+    TF_CHECK_OK(InitFunctionLibraryRuntime({}, thread_pool_));
+    TF_CHECK_OK(RunOpKernel());
+
+    TF_CHECK_OK(GetDatasetOutputFromContext(output_index));
+    return Status::OK();
+  }
+
+  Status MakeIteratorContext() {
+    iteratorContext_ = new IteratorContext(context_.get());
+    return Status::OK();
+  }
+
+  Status MakeIterator() {
+    iterator_.reset(nullptr);
+    TF_CHECK_OK(
+        dataset_->MakeIterator(iteratorContext_, "Iterator", &iterator_));
+    return Status::OK();
+  }
+
+  Status GetNext(std::vector<Tensor>* out_tensors, bool* end_of_sequence) {
+    TF_CHECK_OK(
+        iterator_->GetNext(iteratorContext_, out_tensors, end_of_sequence));
+    return Status::OK();
+  }
+
+ protected:
+  std::unique_ptr<DeviceMgr> device_mgr_;
+  FunctionLibraryRuntime* flr_;
+  std::unique_ptr<FunctionLibraryDefinition> lib_def_;
+  std::unique_ptr<ProcessFunctionLibraryRuntime> pflr_;
+  FunctionDefLibrary fdef_lib_;
+  thread::ThreadPool* thread_pool_;
+  std::function<void(std::function<void()>)> runner_;
+  DatasetBase* dataset_;
+  IteratorContext* iteratorContext_;
+  std::unique_ptr<IteratorBase> iterator_;
+};
+
+TEST_F(RangeDatasetOpTest, GetNext) {
+  MakeOpDef<int64>();
+  int start = 0, end = 10, step = 1;
+  TF_CHECK_OK(MakeDataset(start, end, step));
+  TF_CHECK_OK(MakeIteratorContext());
+  TF_CHECK_OK(MakeIterator());
+  bool end_of_sequence = false;
+  std::vector<Tensor>* out_tensors = new std::vector<Tensor>();
+
+  while (!end_of_sequence) {
+    TF_CHECK_OK(GetNext(out_tensors, &end_of_sequence));
+  }
+
+  std::vector<int64> expected_values;
+  for (int i = start; i < end; i = i + step) {
+    expected_values.emplace_back(i);
+  }
+
+  EXPECT_EQ(out_tensors->size(), expected_values.size());
+
+  for (size_t i = 0; i < out_tensors->size(); ++i) {
+    int64 actual_value = out_tensors->at(i).flat<int64>()(0);
+    int64 expect_value = expected_values[i];
+    EXPECT_EQ(actual_value, expect_value);
+  }
+}
+
+}  // namespace
+}  // namespace data
+}  // namespace tensorflow


### PR DESCRIPTION
# Motivation   (from @jsimsa)

The goal is to develop C++ infrastructure for testing tf.data kernel implementations in C++. Currently, the C++ tf.data kernels are only tested through Python bindings which are not fine-grained enough and some public C++ APIs are not always tested.

The flow of testing the C++ API would be:
* create an instance of the dataset op 
* invoke the `Compute` method which takes input arguments and produces `DatasetBase` object wrapped in a `variant`
* test the public API of the `DatasetBase` object, including the `MakeIterator` method which produces `IteratorBase` object
* test the public API of the `IteratorBase` object

# Progress

- [x] Developed an example for testing some public APIs for `RangeDataset`
- [ ] Add the tests for all the public APIs
    - [x] DatasetBase::name()
    - [x] DatasetBase::output_dtypes()  
    - [x] DatasetBase::output_shapes()
    - [x] DatasetBase::Cardinality()
    - [x] DatasetBase::Save()
    - [x] IteratorBase::output_dtypes()
    - [x] IteratorBase::output_shapes()
    - [x] IteratorBase::output_prefix()
    - [x] IteratorBase::Save()
    - [x] IteratorBase::Restore()
- [ ] Design `DatasetOpsTestBase` as the test base class
- [ ] Add tests for other Dataset Ops
