### PR TITLE
[WIP] Add tests for MapDataset C++ kernel

### DIFF
--- a/tensorflow/core/kernels/data/BUILD
+++ b/tensorflow/core/kernels/data/BUILD
@@ -22,6 +22,26 @@ cc_library(
 )
 
 cc_library(
+    name = "dataset_test_base",
+    testonly = 1,
+    srcs = ["dataset_test_base.cc"],
+    hdrs = ["dataset_test_base.h"],
+    deps = [
+        ":iterator_ops",
+        "//tensorflow/core:core_cpu",
+        "//tensorflow/core:core_cpu_internal",
+        "//tensorflow/core:framework",
+        "//tensorflow/core:lib",
+        "//tensorflow/core:lib_internal",
+        "//tensorflow/core:protos_all_cc",
+        "//tensorflow/core:tensor_testutil",
+        "//tensorflow/core:test",
+        "//tensorflow/core:testlib",
+        "//tensorflow/core/kernels:ops_testutil",
+    ],
+)
+
+cc_library(
     name = "dataset_utils",
     srcs = ["dataset_utils.cc"],
     hdrs = ["dataset_utils.h"],
@@ -177,6 +197,26 @@ tf_kernel_library(
         "//tensorflow/core:dataset_ops_op_lib",
         "//tensorflow/core:framework",
         "//tensorflow/core:lib_internal",
+    ],
+)
+
+tf_cc_test(
+    name = "map_dataset_op_test",
+    size = "small",
+    srcs = ["map_dataset_op_test.cc"],
+    deps = [
+        ":map_dataset_op",
+        ":range_dataset_op",
+        ":dataset_test_base",
+        ":iterator_ops",
+        "//tensorflow/core:testlib",
+        "//tensorflow/core:test_main",
+        "//tensorflow/core:core_cpu_internal",
+        "//tensorflow/core:dataset_ops_op_lib",
+        "//tensorflow/core:framework",
+        "//tensorflow/core:lib_internal",
+        "//tensorflow/core/kernels:function_ops",
+        "//tensorflow/core/kernels:cwise_op",
     ],
 )
 
@@ -349,6 +389,7 @@ tf_cc_test(
     size = "small",
     srcs = ["range_dataset_op_test.cc"],
     deps = [
+        ":dataset_test_base",
         ":range_dataset_op",
         ":iterator_ops",
         "//tensorflow/core:testlib",

--- a/tensorflow/core/kernels/data/dataset_test_base.cc
+++ b/tensorflow/core/kernels/data/dataset_test_base.cc
@@ -1,0 +1,216 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifdef GOOGLE_CUDA
+#define EIGEN_USE_GPU
+#include "tensorflow/core/common_runtime/gpu/gpu_managed_allocator.h"
+#endif
+
+#include "dataset_test_base.h"
+
+namespace tensorflow {
+namespace data {
+
+Status DatasetOpsTestBase::InitThreadPool(int thread_num) {
+  if (thread_num < 1) {
+    return errors::InvalidArgument(
+        "The `thread_num` argument should be but got: ", thread_num);
+  }
+  thread_pool_ = MakeUnique<thread::ThreadPool>(Env::Default(), ThreadOptions(),
+                                                "inter_op", thread_num);
+  return Status::OK();
+}
+
+Status DatasetOpsTestBase::InitFunctionLibraryRuntime(
+    const std::vector<FunctionDef>& flib, int cpu_num) {
+  if (cpu_num < 1) {
+    return errors::InvalidArgument(
+        "The `cpu_num` argument should be positive but got: ", cpu_num);
+  }
+  SessionOptions options;
+  auto* device_count = options.config.mutable_device_count();
+  device_count->insert({"CPU", cpu_num});
+  std::vector<std::unique_ptr<Device>> devices;
+  TF_RETURN_IF_ERROR(DeviceFactory::AddDevices(
+      options, "/job:localhost/replica:0/task:0", &devices));
+  device_mgr_ = MakeUnique<DeviceMgr>(std::move(devices));
+
+  FunctionDefLibrary proto;
+  for (const auto& fdef : flib) *(proto.add_function()) = fdef;
+  lib_def_ = MakeUnique<FunctionLibraryDefinition>(OpRegistry::Global(), proto);
+
+  OptimizerOptions opts;
+  pflr_ = MakeUnique<ProcessFunctionLibraryRuntime>(
+      device_mgr_.get(), Env::Default(), TF_GRAPH_DEF_VERSION, lib_def_.get(),
+      opts, thread_pool_.get(), nullptr /* cluster_flr */);
+  flr_ = pflr_->GetFLR("/job:localhost/replica:0/task:0/cpu:0");
+  if (thread_pool_ == nullptr) {
+    runner_ = [](std::function<void()> fn) { fn(); };
+  } else {
+    runner_ = [this](std::function<void()> fn) {
+      thread_pool_->Schedule(std::move(fn));
+    };
+  }
+  return Status::OK();
+}
+
+Status DatasetOpsTestBase::InitDatasetFromContext(OpKernelContext* context,
+                                                  int output_index,
+                                                  DatasetBase** dataset) {
+  Status status;
+  Tensor* output = GetOutput(context, output_index, &status);
+  TF_RETURN_IF_ERROR(GetDatasetFromVariantTensor(*output, dataset));
+  (*dataset)->Ref();
+  return status;
+}
+
+Tensor* DatasetOpsTestBase::GetOutput(OpKernelContext* context,
+                                      int output_index, Status* status) {
+  if (output_index >= context->num_outputs()) {
+    *status = errors::InvalidArgument(
+        "The 'output_index' should be less than the output number( ",
+        context->num_outputs(), ") but got: ", output_index);
+  }
+  Tensor* output = context->mutable_output(output_index);
+#ifdef GOOGLE_CUDA
+  if (device_type_ == DEVICE_GPU) {
+    managed_outputs_.resize(context_->num_outputs());
+    // Copy the output tensor to managed memory if we haven't done so.
+    if (!managed_outputs_[output_index]) {
+      Tensor* managed_output =
+          new Tensor(allocator(), output->dtype(), output->shape());
+      auto src = output->tensor_data();
+      auto dst = managed_output->tensor_data();
+      context_->eigen_gpu_device().memcpy(const_cast<char*>(dst.data()),
+                                          src.data(), src.size());
+      context_->eigen_gpu_device().synchronize();
+      managed_outputs_[output_index] = managed_output;
+    }
+    output = managed_outputs_[output_index];
+  }
+#endif
+  return output;
+}
+
+Status DatasetOpsTestBase::InitOpKernelContext(
+    OpKernel* kernel, gtl::InlinedVector<TensorValue, 4>* inputs,
+    std::unique_ptr<OpKernelContext>* context) {
+  params_ = MakeUnique<OpKernelContext::Params>();
+  params_->device = device_.get();
+  params_->resource_manager = device_->resource_manager();
+  params_->frame_iter = FrameAndIter(0, 0);
+  params_->inputs = inputs;
+  params_->op_kernel = kernel;
+  params_->function_library = flr_;
+  params_->runner = &runner_;
+  step_container_ = MakeUnique<ScopedStepContainer>(0, [](const string&) {});
+  params_->step_container = step_container_.get();
+  checkpoint::TensorSliceReaderCacheWrapper slice_reader_cache_wrapper;
+  params_->slice_reader_cache = &slice_reader_cache_wrapper;
+  SetOutputAttrs();
+  *context = MakeUnique<OpKernelContext>(params_.get());
+  return Status::OK();
+}
+
+Status DatasetOpsTestBase::RunOpKernel(OpKernel* op_kernel,
+                                       OpKernelContext* context) {
+  device_->Compute(op_kernel, context);
+  return context->status();
+}
+
+void DatasetOpsTestBase::InitSerializationContext(
+    std::unique_ptr<SerializationContext>& serialization_context_) {
+  SerializationContext::Params params;
+  params.flib_def = lib_def_.get();
+  serialization_context_ = MakeUnique<SerializationContext>(params);
+}
+
+Status DatasetOpsTestBase::MakeOpKernel(NodeDef node_def,
+                                        std::unique_ptr<OpKernel>& kernel) {
+  Status status;
+  kernel = CreateOpKernel(device_type_, device_.get(), allocator(), node_def,
+                          TF_GRAPH_DEF_VERSION, &status);
+  TF_RETURN_IF_ERROR(status);
+  return status;
+}
+
+Tensor* DatasetOpsTestBase::AddDatasetInput(
+    gtl::InlinedVector<TensorValue, 4>* inputs, DataTypeVector input_types,
+    DataType dtype, const TensorShape& shape) {
+  CHECK_GT(input_types.size(), inputs->size())
+      << "Adding more inputs than types; perhaps you need to call MakeOp";
+  bool is_ref = IsRefType(input_types[inputs->size()]);
+  Tensor* input = new Tensor(allocator(), dtype, shape);
+  tensors_.push_back(input);
+  if (is_ref) {
+    CHECK_EQ(RemoveRefType(input_types[inputs->size()]), dtype);
+    inputs->push_back({&lock_for_refs_, input});
+  } else {
+    CHECK_EQ(input_types[inputs->size()], dtype);
+    inputs->push_back({nullptr, input});
+  }
+  return input;
+}
+
+Status DatasetOpsTestBase::MakeDataset(OpKernel* kernel,
+                                       OpKernelContext* context) {
+  device_->Compute(kernel, context);
+  return context->status();
+}
+
+Status DatasetOpsTestBase::MakeIterator(
+    OpKernelContext* context, DatasetBase* dataset,
+    std::unique_ptr<IteratorContext>* iterator_context,
+    std::unique_ptr<IteratorBase>* iterator) {
+  *iterator_context = MakeUnique<IteratorContext>(context);
+  IteratorContext::Params params(iterator_context->get());
+  params.function_handle_cache = new FunctionHandleCache(flr_);
+  iterator_context->reset(new IteratorContext(params));
+  return dataset->MakeIterator(iterator_context->get(), "Iterator", iterator);
+}
+
+Status DatasetOpsTestBase::GetNext(IteratorBase* iterator,
+                                   IteratorContext* iterator_context,
+                                   std::vector<Tensor>* out_tensors,
+                                   bool* end_of_sequence) {
+  return iterator->GetNext(iterator_context, out_tensors, end_of_sequence);
+}
+
+Allocator* DatasetOpsTestBase::allocator() { return allocator_; }
+
+void DatasetOpsTestBase::SetOutputAttrs() {
+  allocator_attrs_.clear();
+  for (int index = 0; index < params_->op_kernel->num_outputs(); index++) {
+    AllocatorAttributes attr;
+    const bool on_host =
+        (params_->op_kernel->output_memory_types()[index] == HOST_MEMORY);
+    attr.set_on_host(on_host);
+    allocator_attrs_.emplace_back(attr);
+  }
+  params_->output_attr_array = gtl::vector_as_array(&allocator_attrs_);
+}
+
+Status DatasetOpsTestBase::CheckOpKernelInput(
+    const OpKernel& kernel, const gtl::InlinedVector<TensorValue, 4>& inputs) {
+  if (kernel.input_types().size() != inputs.size()) {
+    return errors::Internal("The number of input elements should be ",
+                            kernel.input_types().size(),
+                            ", but got: ", inputs.size());
+  }
+  return Status::OK();
+}
+
+}  // namespace data
+}  // namespace tensorflow

--- a/tensorflow/core/kernels/data/dataset_test_base.h
+++ b/tensorflow/core/kernels/data/dataset_test_base.h
@@ -1,0 +1,129 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_DATASET_TEST_BASE_H
+#define TENSORFLOW_DATASET_TEST_BASE_H
+
+#include <memory>
+#include <tuple>
+#include <vector>
+
+#include "tensorflow/core/framework/dataset.h"
+#include "tensorflow/core/framework/function.h"
+#include "tensorflow/core/framework/function_handle_cache.h"
+#include "tensorflow/core/framework/function_testlib.h"
+#include "tensorflow/core/framework/node_def_builder.h"
+#include "tensorflow/core/framework/partial_tensor_shape.h"
+#include "tensorflow/core/framework/variant.h"
+#include "tensorflow/core/framework/variant_tensor_data.h"
+#include "tensorflow/core/kernels/data/dataset_utils.h"
+#include "tensorflow/core/kernels/data/iterator_ops.h"
+#include "tensorflow/core/kernels/ops_testutil.h"
+#include "tensorflow/core/platform/test.h"
+#include "tensorflow/core/platform/types.h"
+#include "tensorflow/core/util/ptr_util.h"
+
+namespace tensorflow {
+namespace data {
+
+class DatasetOpsTestBase : public ::testing::Test {
+ public:
+  DatasetOpsTestBase()
+      : device_(DeviceFactory::NewDevice("CPU", {}, "/job:a/replica:0/task:0")),
+        device_type_(DEVICE_CPU) {
+    CHECK(device_.get()) << "Could not create CPU device";
+    allocator_ = device_->GetAllocator(AllocatorAttributes());
+  }
+
+  ~DatasetOpsTestBase() {
+    gtl::STLDeleteElements(&tensors_);
+    gtl::STLDeleteElements(&managed_outputs_);
+  }
+
+  Status InitThreadPool(int thread_num);
+
+  Status InitFunctionLibraryRuntime(const std::vector<FunctionDef>& flib,
+                                    int cpu_num);
+
+  Status InitDatasetFromContext(OpKernelContext* context, int output_index,
+                                DatasetBase** dataset);
+
+  Tensor* GetOutput(OpKernelContext* context, int output_index, Status* status);
+
+  Status InitOpKernelContext(OpKernel* kernel,
+                             gtl::InlinedVector<TensorValue, 4>* inputs,
+                             std::unique_ptr<OpKernelContext>* context);
+
+  Status RunOpKernel(OpKernel* op_kernel, OpKernelContext* context);
+
+  void InitSerializationContext(
+      std::unique_ptr<SerializationContext>& serialization_context_);
+
+  Status MakeOpKernel(NodeDef node_def, std::unique_ptr<OpKernel>& kernel);
+
+  template <typename T>
+  void AddDatasetInputFromArray(gtl::InlinedVector<TensorValue, 4>* inputs,
+                                DataTypeVector input_types,
+                                const TensorShape& shape,
+                                const gtl::ArraySlice<T>& data) {
+    Tensor* input =
+        AddDatasetInput(inputs, input_types, DataTypeToEnum<T>::v(), shape);
+    test::FillValues<T>(input, data);
+  }
+
+  Tensor* AddDatasetInput(gtl::InlinedVector<TensorValue, 4>* inputs,
+                          DataTypeVector input_types, DataType dtype,
+                          const TensorShape& shape);
+
+  Status MakeDataset(OpKernel* kernel, OpKernelContext* context);
+
+  Status MakeIterator(OpKernelContext* context, DatasetBase* dataset,
+                      std::unique_ptr<IteratorContext>* iterator_context,
+                      std::unique_ptr<IteratorBase>* iterator);
+
+  Status GetNext(IteratorBase* iterator, IteratorContext* iterator_context,
+                 std::vector<Tensor>* out_tensors, bool* end_of_sequence);
+
+  Allocator* allocator();
+
+  void SetOutputAttrs();
+
+  Status CheckOpKernelInput(const OpKernel& kernel,
+                            const gtl::InlinedVector<TensorValue, 4>& inputs);
+
+ protected:
+  std::unique_ptr<Device> device_;
+  DeviceType device_type_;
+  Allocator* allocator_;
+  std::vector<AllocatorAttributes> allocator_attrs_;
+  std::unique_ptr<ScopedStepContainer> step_container_;
+
+  FunctionLibraryRuntime* flr_;  // not owned
+  std::function<void(std::function<void()>)> runner_;
+  std::unique_ptr<DeviceMgr> device_mgr_;
+  std::unique_ptr<FunctionLibraryDefinition> lib_def_;
+  std::unique_ptr<OpKernelContext::Params> params_;
+  std::unique_ptr<ProcessFunctionLibraryRuntime> pflr_;
+  std::unique_ptr<thread::ThreadPool> thread_pool_;
+  std::vector<Tensor*> tensors_;  // owns Tensors.
+  // Copies of the outputs in unified memory (host and device accessible).
+  std::vector<Tensor*> managed_outputs_;
+  mutex lock_for_refs_;  // Used as the Mutex for inputs added as refs
+};
+
+}  // namespace data
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_DATASET_TEST_BASE_H

--- a/tensorflow/core/kernels/data/dataset_test_base.h
+++ b/tensorflow/core/kernels/data/dataset_test_base.h
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#ifndef TENSORFLOW_DATASET_TEST_BASE_H
-#define TENSORFLOW_DATASET_TEST_BASE_H
+#ifndef TENSORFLOW_CORE_KERNELS_DATA_DATASET_TEST_BASE_H
+#define TENSORFLOW_CORE_KERNELS_DATA_DATASET_TEST_BASE_H
 
 #include <memory>
 #include <tuple>
@@ -38,6 +38,7 @@ limitations under the License.
 namespace tensorflow {
 namespace data {
 
+// Helpful functions to test dataset kernels.
 class DatasetOpsTestBase : public ::testing::Test {
  public:
   DatasetOpsTestBase()
@@ -52,27 +53,98 @@ class DatasetOpsTestBase : public ::testing::Test {
     gtl::STLDeleteElements(&managed_outputs_);
   }
 
+  // Creates a new operation based on the node definition.
+  std::unique_ptr<OpKernel> CreateOpKernel(const NodeDef& node_def);
+
+  // Creates a new dataset. Here we assume that the dataset operation has only
+  // one output stored in the OpKernelContext.
+  DatasetBase* CreateDataset(OpKernel* kernel, OpKernelContext* context);
+
+  // Creates a new iterator for iterating over the range of elements in this
+  // dataset. Meanwhile, `iterator_context` will be initialized internally.
+  //
+  // This method may be called multiple times on the same dataset, and the
+  // resulting iterators will have distinct state.
+  std::unique_ptr<IteratorBase> CreateIterator(
+      OpKernelContext* context, DatasetBase* dataset,
+      std::unique_ptr<IteratorContext>* iterator_context);
+
+  // Gets the next output from the range that this iterator is traversing.
+  //
+  // If at least one output remains in this iterator's range, that
+  // output will be stored in `*out_tensors` and `false` will be
+  // stored in `*end_of_sequence`.
+  //
+  // If no more outputs remain in this iterator's range, `true` will
+  // be stored in `*end_of_sequence`, and the content of
+  // `*out_tensors` will be undefined.
+  Status GetNext(IteratorBase* iterator, IteratorContext* iterator_context,
+                 std::vector<Tensor>* out_tensors, bool* end_of_sequence);
+
+  // Creates a new range dataset operation.
+  template <typename T>
+  std::unique_ptr<OpKernel> CreateRangeDatasetOpKernel(StringPiece node_name) {
+    DataTypeVector dtypes({tensorflow::DataTypeToEnum<T>::value});
+    std::vector<PartialTensorShape> shapes({{}});
+    NodeDef node_def = test::function::NDef(
+        node_name, "RangeDataset", {"start", "stop", "step"},
+        {{"output_types", dtypes}, {"output_shapes", shapes}});
+    return CreateOpKernel(node_def);
+  }
+
+  // Creates a new range dataset.
+  template <typename U>
+  DatasetBase* CreateRangeDataset(int64 start, int64 end, int64 step,
+                                  StringPiece node_name) {
+    std::unique_ptr<OpKernel> range_kernel =
+        CreateRangeDatasetOpKernel<U>(node_name);
+    std::unique_ptr<OpKernelContext> range_context;
+    gtl::InlinedVector<TensorValue, 4> range_inputs;
+    AddDatasetInputFromArray<int64>(&range_inputs, range_kernel->input_types(),
+                                    TensorShape({}), {start});
+    AddDatasetInputFromArray<int64>(&range_inputs, range_kernel->input_types(),
+                                    TensorShape({}), {end});
+    AddDatasetInputFromArray<int64>(&range_inputs, range_kernel->input_types(),
+                                    TensorShape({}), {step});
+    range_context = CreateOpKernelContext(range_kernel.get(), &range_inputs);
+    TF_CHECK_OK(CheckOpKernelInput(*range_kernel, range_inputs));
+    TF_CHECK_OK(RunOpKernel(range_kernel.get(), range_context.get()));
+    return GetDatasetFromContext(range_context.get(), 0);
+  }
+
+  // Fetches the dataset from the operation context.
+  DatasetBase* GetDatasetFromContext(OpKernelContext* context,
+                                     int output_index);
+
+ protected:
+  // Creates a thread pool for parallel tasks.
   Status InitThreadPool(int thread_num);
 
+  // Initializes the runtime for computing the dataset operation and registers
+  // the input function definitions. `InitThreadPool()' needs to be called
+  // before this method if we want to run the tasks in parallel.
   Status InitFunctionLibraryRuntime(const std::vector<FunctionDef>& flib,
                                     int cpu_num);
 
-  Status InitDatasetFromContext(OpKernelContext* context, int output_index,
-                                DatasetBase** dataset);
-
-  Tensor* GetOutput(OpKernelContext* context, int output_index, Status* status);
-
-  Status InitOpKernelContext(OpKernel* kernel,
-                             gtl::InlinedVector<TensorValue, 4>* inputs,
-                             std::unique_ptr<OpKernelContext>* context);
-
+  // Runs an operation producing outputs. The `context` need to be initialized
+  // (see `CreateOpKernelContext()` ) before running this method.
   Status RunOpKernel(OpKernel* op_kernel, OpKernelContext* context);
 
-  void InitSerializationContext(
-      std::unique_ptr<SerializationContext>& serialization_context_);
+  // Checks that the size of `inputs` matches the requirement of the operation.
+  Status CheckOpKernelInput(const OpKernel& kernel,
+                            const gtl::InlinedVector<TensorValue, 4>& inputs);
 
-  Status MakeOpKernel(NodeDef node_def, std::unique_ptr<OpKernel>& kernel);
+  // Creates a new context for running the dataset operation.
+  std::unique_ptr<OpKernelContext> CreateOpKernelContext(
+      OpKernel* kernel, gtl::InlinedVector<TensorValue, 4>* inputs);
 
+  // Returns a new serialization context for serializing the dataset and
+  // iterator.
+  std::unique_ptr<SerializationContext> CreateSerializationContext();
+
+  // Adds an arrayslice of data into the input vector. `input_types` describes
+  // the required data type for each input tensor. `shape` and `data` describes
+  // the shape and values of the current input tensor.
   template <typename T>
   void AddDatasetInputFromArray(gtl::InlinedVector<TensorValue, 4>* inputs,
                                 DataTypeVector input_types,
@@ -83,25 +155,15 @@ class DatasetOpsTestBase : public ::testing::Test {
     test::FillValues<T>(input, data);
   }
 
+ private:
+  // Adds an empty tensor to the input vector. The returned pointer can be used
+  // to fill in the value for the tensor.
   Tensor* AddDatasetInput(gtl::InlinedVector<TensorValue, 4>* inputs,
                           DataTypeVector input_types, DataType dtype,
                           const TensorShape& shape);
 
-  Status MakeDataset(OpKernel* kernel, OpKernelContext* context);
-
-  Status MakeIterator(OpKernelContext* context, DatasetBase* dataset,
-                      std::unique_ptr<IteratorContext>* iterator_context,
-                      std::unique_ptr<IteratorBase>* iterator);
-
-  Status GetNext(IteratorBase* iterator, IteratorContext* iterator_context,
-                 std::vector<Tensor>* out_tensors, bool* end_of_sequence);
-
-  Allocator* allocator();
-
+  // Sets the allocator attributes for the operation outputs.
   void SetOutputAttrs();
-
-  Status CheckOpKernelInput(const OpKernel& kernel,
-                            const gtl::InlinedVector<TensorValue, 4>& inputs);
 
  protected:
   std::unique_ptr<Device> device_;
@@ -126,4 +188,4 @@ class DatasetOpsTestBase : public ::testing::Test {
 }  // namespace data
 }  // namespace tensorflow
 
-#endif  // TENSORFLOW_DATASET_TEST_BASE_H
+#endif  // TENSORFLOW_CORE_KERNELS_DATA_DATASET_TEST_BASE_H

--- a/tensorflow/core/kernels/data/map_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/map_dataset_op_test.cc
@@ -286,6 +286,7 @@ TEST_P(DatasetCardinalityTest, Cardinality) {
   TF_ASSERT_OK(CreateRangeDataset<int64>(test_params.start, test_params.end,
                                          test_params.step, "range",
                                          &range_dataset));
+  core::ScopedUnref scored_unref_range_dataset(range_dataset);
 
   std::unique_ptr<OpKernel> map_kernel;
   TF_ASSERT_OK(CreateMapDatasetOpKernel<int64>(
@@ -479,6 +480,8 @@ TEST_P(IteratorRoundtripTest, Roundtrip) {
   TF_ASSERT_OK(CreateRangeDataset<int64>(test_params.start, test_params.end,
                                          test_params.step, "range",
                                          &range_dataset));
+  core::ScopedUnref scored_unref_range_dataset(range_dataset);
+
   std::unique_ptr<OpKernel> map_kernel;
   TF_ASSERT_OK(CreateMapDatasetOpKernel<int64>(
       range_dataset->name(), test_params.func_name, &map_kernel));

--- a/tensorflow/core/kernels/data/map_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/map_dataset_op_test.cc
@@ -1,0 +1,384 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <tuple>
+#include "tensorflow/core/framework/dataset.h"
+#include "tensorflow/core/framework/fake_input.h"
+#include "tensorflow/core/framework/function.h"
+#include "tensorflow/core/framework/function_handle_cache.h"
+#include "tensorflow/core/framework/function_testlib.h"
+#include "tensorflow/core/framework/node_def_builder.h"
+#include "tensorflow/core/framework/partial_tensor_shape.h"
+#include "tensorflow/core/framework/variant.h"
+#include "tensorflow/core/framework/variant_tensor_data.h"
+#include "tensorflow/core/kernels/data/dataset_test_base.h"
+#include "tensorflow/core/kernels/data/dataset_utils.h"
+#include "tensorflow/core/kernels/data/iterator_ops.h"
+#include "tensorflow/core/kernels/ops_testutil.h"
+#include "tensorflow/core/platform/test.h"
+#include "tensorflow/core/util/ptr_util.h"
+
+namespace tensorflow {
+namespace data {
+namespace {
+
+class MapDatasetOpTest : public DatasetOpsTestBase {
+ public:
+  static const char* kNodeName;
+  static const char* kOpName;
+
+  ~MapDatasetOpTest() override {
+    gtl::STLDeleteElements(&tensors_);
+    range_dataset_->Unref();
+  }
+
+ public:
+  FunctionDef MakeFuncDef() { return test::function::XTimesTwo(); }
+
+  string FuncName() { return "XTimesTwo"; }
+  template <typename T>
+  Status MakeRangeDatasetOpKernel() {
+    DataTypeVector dtypes({tensorflow::DataTypeToEnum<T>::value});
+    std::vector<PartialTensorShape> shapes({{}});
+    range_node_def_ = test::function::NDef(
+        "range", "RangeDataset", {"start", "stop", "step"},
+        {{"output_types", dtypes}, {"output_shapes", shapes}});
+    TF_RETURN_IF_ERROR(MakeOpKernel(range_node_def_, range_kernel_));
+    return Status::OK();
+  }
+
+  Status MakeRangeDataset(int start, int end, int step, int output_index) {
+    range_inputs_.clear();
+    AddDatasetInputFromArray<int64>(
+        &range_inputs_, range_kernel_->input_types(), TensorShape({}), {start});
+    AddDatasetInputFromArray<int64>(
+        &range_inputs_, range_kernel_->input_types(), TensorShape({}), {end});
+    AddDatasetInputFromArray<int64>(
+        &range_inputs_, range_kernel_->input_types(), TensorShape({}), {step});
+    TF_RETURN_IF_ERROR(InitOpKernelContext(range_kernel_.get(), &range_inputs_,
+                                           &range_context_));
+    TF_RETURN_IF_ERROR(CheckOpKernelInput(*range_kernel_, range_inputs_));
+    TF_RETURN_IF_ERROR(RunOpKernel(range_kernel_.get(), range_context_.get()));
+    TF_RETURN_IF_ERROR(InitDatasetFromContext(range_context_.get(),
+                                              output_index, &range_dataset_));
+    return Status::OK();
+  }
+
+  template <typename T>
+  Status MakeMapDatasetOpKernel() {
+    DataTypeVector map_output_dtypes({tensorflow::DataTypeToEnum<T>::value});
+    gtl::ArraySlice<TensorShape> map_output_shapes({{}});
+    FunctionDefHelper::AttrValueWrapper func =
+        FunctionDefHelper::FunctionRef(FuncName(), {{"T", DT_INT64}});
+
+    map_node_def_ = test::function::NDef(kNodeName, kOpName, {"range"},
+                                         {{"f", func},
+                                          {"Targuments", {}},
+                                          {"output_shapes", map_output_shapes},
+                                          {"output_types", map_output_dtypes},
+                                          {"use_inter_op_parallelism", true},
+                                          {"preserve_cardinality", false}});
+    TF_RETURN_IF_ERROR(MakeOpKernel(map_node_def_, map_kernel_));
+    return Status::OK();
+  }
+
+  Status MakeMapDataset(DatasetBase* input_dataset, int output_index) {
+    map_inputs_.clear();
+    range_context_.reset();
+    Tensor dataset_tensor(DT_VARIANT, TensorShape({}));
+    TF_RETURN_IF_ERROR(
+        StoreDatasetInVariantTensor(input_dataset, &dataset_tensor));
+    Variant variant = dataset_tensor.scalar<Variant>()();
+    AddDatasetInputFromArray<Variant>(&map_inputs_, map_kernel_->input_types(),
+                                      TensorShape({}), {variant});
+
+    TF_RETURN_IF_ERROR(
+        InitOpKernelContext(map_kernel_.get(), &map_inputs_, &map_context_));
+    TF_RETURN_IF_ERROR(CheckOpKernelInput(*map_kernel_, map_inputs_));
+    TF_RETURN_IF_ERROR(RunOpKernel(map_kernel_.get(), map_context_.get()));
+    TF_RETURN_IF_ERROR(InitDatasetFromContext(map_context_.get(), output_index,
+                                              &map_dataset_));
+    return Status::OK();
+  }
+
+ protected:
+  NodeDef range_node_def_;
+  gtl::InlinedVector<TensorValue, 4> range_inputs_;
+  std::unique_ptr<OpKernel> range_kernel_;
+  DatasetBase* range_dataset_;
+  std::unique_ptr<OpKernelContext> range_context_;
+
+  NodeDef map_node_def_;
+  DatasetBase* map_dataset_;
+  gtl::InlinedVector<TensorValue, 4> map_inputs_;
+  std::unique_ptr<OpKernel> map_kernel_;
+  std::unique_ptr<OpKernelContext> map_context_;
+  std::unique_ptr<IteratorContext> iterator_context_;
+  std::unique_ptr<IteratorBase> iterator_;
+
+  std::unique_ptr<SerializationContext> serialization_context_;
+};
+
+const char* MapDatasetOpTest::kNodeName = "map_dataset";
+const char* MapDatasetOpTest::kOpName = "MapDataset";
+
+struct DatasetGetNextTest
+    : MapDatasetOpTest,
+      ::testing::WithParamInterface<std::tuple<int, int, int>> {};
+
+TEST_P(DatasetGetNextTest, GetNext) {
+  int output_index = 0, thread_num = 2, cpu_num = 2;
+  int start = std::get<0>(GetParam());
+  int end = std::get<1>(GetParam());
+  int step = std::get<2>(GetParam());
+  TF_ASSERT_OK(InitThreadPool(thread_num));
+  TF_ASSERT_OK(InitFunctionLibraryRuntime({MakeFuncDef()}, cpu_num));
+
+  TF_ASSERT_OK(MakeRangeDatasetOpKernel<int64>());
+  TF_ASSERT_OK(MakeRangeDataset(start, end, step, output_index));
+
+  TF_ASSERT_OK(MakeMapDatasetOpKernel<int64>());
+  TF_ASSERT_OK(MakeMapDataset(range_dataset_, 0));
+  TF_ASSERT_OK(MakeIterator(map_context_.get(), map_dataset_,
+                            &iterator_context_, &iterator_));
+
+  bool end_of_sequence = false;
+  std::vector<Tensor> out_tensors;
+  while (!end_of_sequence) {
+    TF_EXPECT_OK(GetNext(iterator_.get(), iterator_context_.get(), &out_tensors,
+                         &end_of_sequence));
+  }
+  std::vector<int64> expected_values;
+  for (int i = start; (end - i) * step > 0; i = i + step) {
+    expected_values.reserve(1);
+    expected_values.emplace_back(i * 2);
+  }
+  EXPECT_EQ(out_tensors.size(), expected_values.size());
+  for (size_t i = 0; i < out_tensors.size(); ++i) {
+    int64 actual_value = out_tensors[i].flat<int64>()(0);
+    int64 expect_value = expected_values[i];
+    EXPECT_EQ(actual_value, expect_value);
+  }
+}
+
+INSTANTIATE_TEST_CASE_P(MapDatasetOpTest, DatasetGetNextTest,
+                        ::testing::Values(std::make_tuple(0, 10, 1),
+                                          std::make_tuple(0, 10, 3),
+                                          std::make_tuple(10, 0, -1),
+                                          std::make_tuple(10, 0, -3)));
+
+TEST_F(MapDatasetOpTest, DatasetName) {
+  int output_index = 0, thread_num = 2, cpu_num = 2;
+  int start = 0, end = 10, step = 1;
+  TF_ASSERT_OK(InitThreadPool(thread_num));
+  TF_ASSERT_OK(InitFunctionLibraryRuntime({MakeFuncDef()}, cpu_num));
+
+  TF_ASSERT_OK(MakeRangeDatasetOpKernel<int64>());
+  TF_ASSERT_OK(MakeRangeDataset(start, end, step, output_index));
+
+  TF_ASSERT_OK(MakeMapDatasetOpKernel<int64>());
+  TF_ASSERT_OK(MakeMapDataset(range_dataset_, 0));
+  EXPECT_EQ(map_dataset_->name(), kOpName);
+}
+
+TEST_F(MapDatasetOpTest, DatasetOutputDtypes) {
+  int output_index = 0, thread_num = 2, cpu_num = 2;
+  int start = 0, end = 10, step = 1;
+  TF_ASSERT_OK(InitThreadPool(thread_num));
+  TF_ASSERT_OK(InitFunctionLibraryRuntime({MakeFuncDef()}, cpu_num));
+
+  TF_ASSERT_OK(MakeRangeDatasetOpKernel<int64>());
+  TF_ASSERT_OK(MakeRangeDataset(start, end, step, output_index));
+
+  TF_ASSERT_OK(MakeMapDatasetOpKernel<int64>());
+  TF_ASSERT_OK(MakeMapDataset(range_dataset_, 0));
+  DataTypeVector expected_dtypes({DT_INT64});
+  EXPECT_EQ(map_dataset_->output_dtypes(), expected_dtypes);
+}
+
+TEST_F(MapDatasetOpTest, DatasetOutputShapes) {
+  int output_index = 0, thread_num = 2, cpu_num = 2;
+  int start = 0, end = 10, step = 1;
+  TF_ASSERT_OK(InitThreadPool(thread_num));
+  TF_ASSERT_OK(InitFunctionLibraryRuntime({MakeFuncDef()}, cpu_num));
+
+  TF_ASSERT_OK(MakeRangeDatasetOpKernel<int64>());
+  TF_ASSERT_OK(MakeRangeDataset(start, end, step, output_index));
+
+  TF_ASSERT_OK(MakeMapDatasetOpKernel<int64>());
+  TF_ASSERT_OK(MakeMapDataset(range_dataset_, 0));
+  std::vector<PartialTensorShape> expected_shapes({{}});
+  EXPECT_EQ(map_dataset_->output_shapes().size(), expected_shapes.size());
+  for (int i = 0; i < map_dataset_->output_shapes().size(); ++i) {
+    map_dataset_->output_shapes()[i].IsIdenticalTo(expected_shapes[i]);
+  }
+}
+
+struct DatasetCardinalityTest
+    : MapDatasetOpTest,
+      ::testing::WithParamInterface<std::tuple<int, int, int, int>> {};
+
+TEST_P(DatasetCardinalityTest, Cardinality) {
+  int output_index = 0, thread_num = 2, cpu_num = 2;
+  int start = std::get<0>(GetParam());
+  int end = std::get<1>(GetParam());
+  int step = std::get<2>(GetParam());
+  int expected_cardinality = std::get<3>(GetParam());
+  TF_ASSERT_OK(InitThreadPool(thread_num));
+  TF_ASSERT_OK(InitFunctionLibraryRuntime({MakeFuncDef()}, cpu_num));
+
+  TF_ASSERT_OK(MakeRangeDatasetOpKernel<int64>());
+  TF_ASSERT_OK(MakeRangeDataset(start, end, step, output_index));
+
+  TF_ASSERT_OK(MakeMapDatasetOpKernel<int64>());
+  TF_ASSERT_OK(MakeMapDataset(range_dataset_, 0));
+  EXPECT_EQ(map_dataset_->Cardinality(), expected_cardinality);
+}
+
+INSTANTIATE_TEST_CASE_P(MapDatasetOpTest, DatasetCardinalityTest,
+                        ::testing::Values(std::make_tuple(0, 10, 1, 10),
+                                          std::make_tuple(0, 10, 3, 4),
+                                          std::make_tuple(10, 0, -3, 4)));
+
+TEST_F(MapDatasetOpTest, DatasetSave) {
+  int output_index = 0, thread_num = 2, cpu_num = 2;
+  int start = 0, end = 10, step = 1;
+  TF_ASSERT_OK(InitThreadPool(thread_num));
+  TF_ASSERT_OK(InitFunctionLibraryRuntime({MakeFuncDef()}, cpu_num));
+
+  TF_ASSERT_OK(MakeRangeDatasetOpKernel<int64>());
+  TF_ASSERT_OK(MakeRangeDataset(start, end, step, output_index));
+
+  TF_ASSERT_OK(MakeMapDatasetOpKernel<int64>());
+  TF_ASSERT_OK(MakeMapDataset(range_dataset_, 0));
+
+  InitSerializationContext(serialization_context_);
+  VariantTensorData data;
+  VariantTensorDataWriter writer(&data);
+  TF_ASSERT_OK(map_dataset_->Save(serialization_context_.get(), &writer));
+  TF_ASSERT_OK(writer.Flush());
+}
+
+TEST_F(MapDatasetOpTest, IteratorOutputDtypes) {
+  int start = 0, end = 10, step = 1;
+  int output_index = 0, thread_num = 2, cpu_num = 2;
+  TF_ASSERT_OK(InitThreadPool(thread_num));
+  TF_ASSERT_OK(InitFunctionLibraryRuntime({MakeFuncDef()}, cpu_num));
+
+  TF_ASSERT_OK(MakeRangeDatasetOpKernel<int64>());
+  TF_ASSERT_OK(MakeRangeDataset(start, end, step, output_index));
+
+  TF_ASSERT_OK(MakeMapDatasetOpKernel<int64>());
+  TF_ASSERT_OK(MakeMapDataset(range_dataset_, 0));
+  TF_ASSERT_OK(MakeIterator(map_context_.get(), map_dataset_,
+                            &iterator_context_, &iterator_));
+  DataTypeVector expected_dtypes({DT_INT64});
+  EXPECT_EQ(iterator_->output_dtypes(), expected_dtypes);
+}
+
+TEST_F(MapDatasetOpTest, IteratorOutputShapes) {
+  int start = 0, end = 10, step = 1;
+  int output_index = 0, thread_num = 2, cpu_num = 2;
+  TF_ASSERT_OK(InitThreadPool(thread_num));
+  TF_ASSERT_OK(InitFunctionLibraryRuntime({MakeFuncDef()}, cpu_num));
+
+  TF_ASSERT_OK(MakeRangeDatasetOpKernel<int64>());
+  TF_ASSERT_OK(MakeRangeDataset(start, end, step, output_index));
+
+  TF_ASSERT_OK(MakeMapDatasetOpKernel<int64>());
+  TF_ASSERT_OK(MakeMapDataset(range_dataset_, 0));
+  TF_ASSERT_OK(MakeIterator(map_context_.get(), map_dataset_,
+                            &iterator_context_, &iterator_));
+  std::vector<PartialTensorShape> expected_shapes({{}});
+  EXPECT_EQ(iterator_->output_shapes().size(), expected_shapes.size());
+  for (int i = 0; i < map_dataset_->output_shapes().size(); ++i) {
+    iterator_->output_shapes()[i].IsIdenticalTo(expected_shapes[i]);
+  }
+}
+
+TEST_F(MapDatasetOpTest, IteratorOutputPrefix) {
+  int start = 0, end = 10, step = 1;
+  int output_index = 0, thread_num = 2, cpu_num = 2;
+  TF_ASSERT_OK(InitThreadPool(thread_num));
+  TF_ASSERT_OK(InitFunctionLibraryRuntime({MakeFuncDef()}, cpu_num));
+
+  TF_ASSERT_OK(MakeRangeDatasetOpKernel<int64>());
+  TF_ASSERT_OK(MakeRangeDataset(start, end, step, output_index));
+
+  TF_ASSERT_OK(MakeMapDatasetOpKernel<int64>());
+  TF_ASSERT_OK(MakeMapDataset(range_dataset_, 0));
+  TF_ASSERT_OK(MakeIterator(map_context_.get(), map_dataset_,
+                            &iterator_context_, &iterator_));
+  EXPECT_EQ(iterator_->prefix(), "Iterator::Map");
+}
+
+struct IteratorRoundtripTest
+    : MapDatasetOpTest,
+      ::testing::WithParamInterface<std::tuple<int, int, int, int>> {};
+
+TEST_P(IteratorRoundtripTest, Roundtrip) {
+  int output_index = 0, thread_num = 2, cpu_num = 2;
+  int start = std::get<0>(GetParam());
+  int end = std::get<1>(GetParam());
+  int step = std::get<2>(GetParam());
+  int breakpoint = std::get<3>(GetParam());
+  TF_ASSERT_OK(InitThreadPool(thread_num));
+  TF_ASSERT_OK(InitFunctionLibraryRuntime({MakeFuncDef()}, cpu_num));
+
+  TF_ASSERT_OK(MakeRangeDatasetOpKernel<int64>());
+  TF_ASSERT_OK(MakeRangeDataset(start, end, step, output_index));
+
+  TF_ASSERT_OK(MakeMapDatasetOpKernel<int64>());
+  TF_ASSERT_OK(MakeMapDataset(range_dataset_, 0));
+  TF_ASSERT_OK(MakeIterator(map_context_.get(), map_dataset_,
+                            &iterator_context_, &iterator_));
+  std::vector<Tensor> out_tensors;
+  bool end_of_sequence = false;
+  int cur_range_val = start - step;
+  for (int i = 0; i < breakpoint; i++) {
+    if (!end_of_sequence) {
+      TF_EXPECT_OK(GetNext(iterator_.get(), iterator_context_.get(),
+                           &out_tensors, &end_of_sequence));
+      cur_range_val = ((end - cur_range_val - step) * step > 0)
+                          ? cur_range_val + step
+                          : cur_range_val;
+    }
+  }
+  InitSerializationContext(serialization_context_);
+  VariantTensorData data;
+  VariantTensorDataWriter writer(&data);
+  TF_ASSERT_OK(iterator_->Save(serialization_context_.get(), &writer));
+  TF_ASSERT_OK(writer.Flush());
+  VariantTensorDataReader reader(&data);
+  TF_ASSERT_OK(iterator_->Restore(iterator_context_.get(), &reader));
+  TF_EXPECT_OK(GetNext(iterator_.get(), iterator_context_.get(), &out_tensors,
+                       &end_of_sequence));
+  int expect_range_next = ((end - cur_range_val - step) * step > 0)
+                              ? cur_range_val + step
+                              : cur_range_val;
+  EXPECT_EQ(out_tensors.back().flat<int64>()(0), expect_range_next * 2);
+}
+
+INSTANTIATE_TEST_CASE_P(
+    MapDatasetOpTest, IteratorRoundtripTest,
+    ::testing::Values(
+        std::make_tuple(0, 10, 2, 0),    // unused_iterator
+        std::make_tuple(0, 10, 2, 4),    // fully_used_iterator_increase
+        std::make_tuple(10, 0, -2, 4),   // fully_used_iterator_decrease
+        std::make_tuple(0, 10, 2, 6)));  // exhausted_iterator
+
+}  // namespace
+}  // namespace data
+}  // namespace tensorflow

--- a/tensorflow/core/kernels/data/map_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/map_dataset_op_test.cc
@@ -44,91 +44,61 @@ class MapDatasetOpTest : public DatasetOpsTestBase {
     range_dataset_->Unref();
   }
 
- public:
-  FunctionDef MakeFuncDef() { return test::function::XTimesTwo(); }
+ protected:
+  // Creates a new MapDataset, meanwhile initializing the operation kernel and
+  // context internally.
+  DatasetBase* CreateMapDataset(DatasetBase* input_dataset,
+                                const string& func_name) {
+    CHECK_EQ(map_inputs_.size(), 0);
+    map_kernel_ =
+        CreateMapDatasetOpKernel<int64>(input_dataset->name(), func_name);
 
-  string FuncName() { return "XTimesTwo"; }
-  template <typename T>
-  Status MakeRangeDatasetOpKernel() {
-    DataTypeVector dtypes({tensorflow::DataTypeToEnum<T>::value});
-    std::vector<PartialTensorShape> shapes({{}});
-    range_node_def_ = test::function::NDef(
-        "range", "RangeDataset", {"start", "stop", "step"},
-        {{"output_types", dtypes}, {"output_shapes", shapes}});
-    TF_RETURN_IF_ERROR(MakeOpKernel(range_node_def_, range_kernel_));
-    return Status::OK();
+    // Save the input dataset into a variant tensor as the input of MapDataset.
+    Tensor dataset_tensor(DT_VARIANT, TensorShape({}));
+    TF_CHECK_OK(StoreDatasetInVariantTensor(input_dataset, &dataset_tensor));
+    Variant variant = dataset_tensor.scalar<Variant>()();
+    AddDatasetInputFromArray<Variant>(&map_inputs_, map_kernel_->input_types(),
+                                      TensorShape({}), {variant});
+
+    map_context_ = CreateOpKernelContext(map_kernel_.get(), &map_inputs_);
+    TF_CHECK_OK(CheckOpKernelInput(*map_kernel_, map_inputs_));
+    return CreateDataset(map_kernel_.get(), map_context_.get());
   }
 
-  Status MakeRangeDataset(int start, int end, int step, int output_index) {
-    range_inputs_.clear();
-    AddDatasetInputFromArray<int64>(
-        &range_inputs_, range_kernel_->input_types(), TensorShape({}), {start});
-    AddDatasetInputFromArray<int64>(
-        &range_inputs_, range_kernel_->input_types(), TensorShape({}), {end});
-    AddDatasetInputFromArray<int64>(
-        &range_inputs_, range_kernel_->input_types(), TensorShape({}), {step});
-    TF_RETURN_IF_ERROR(InitOpKernelContext(range_kernel_.get(), &range_inputs_,
-                                           &range_context_));
-    TF_RETURN_IF_ERROR(CheckOpKernelInput(*range_kernel_, range_inputs_));
-    TF_RETURN_IF_ERROR(RunOpKernel(range_kernel_.get(), range_context_.get()));
-    TF_RETURN_IF_ERROR(InitDatasetFromContext(range_context_.get(),
-                                              output_index, &range_dataset_));
-    return Status::OK();
-  }
-
+ private:
+  // Creates a new MapDatasetOp kernel. The `input_dataset` parameter should be
+  // same with the node name of the input dataset for the method
+  // `CreateMapDataset()`.
   template <typename T>
-  Status MakeMapDatasetOpKernel() {
+  std::unique_ptr<OpKernel> CreateMapDatasetOpKernel(
+      const string& input_dataset, const string& func_name) {
     DataTypeVector map_output_dtypes({tensorflow::DataTypeToEnum<T>::value});
     gtl::ArraySlice<TensorShape> map_output_shapes({{}});
     FunctionDefHelper::AttrValueWrapper func =
-        FunctionDefHelper::FunctionRef(FuncName(), {{"T", DT_INT64}});
+        FunctionDefHelper::FunctionRef(func_name, {{"T", DT_INT64}});
 
-    map_node_def_ = test::function::NDef(kNodeName, kOpName, {"range"},
+    map_node_def_ = test::function::NDef(kNodeName, kOpName, {input_dataset},
                                          {{"f", func},
                                           {"Targuments", {}},
                                           {"output_shapes", map_output_shapes},
                                           {"output_types", map_output_dtypes},
                                           {"use_inter_op_parallelism", true},
                                           {"preserve_cardinality", false}});
-    TF_RETURN_IF_ERROR(MakeOpKernel(map_node_def_, map_kernel_));
-    return Status::OK();
-  }
-
-  Status MakeMapDataset(DatasetBase* input_dataset, int output_index) {
-    map_inputs_.clear();
-    range_context_.reset();
-    Tensor dataset_tensor(DT_VARIANT, TensorShape({}));
-    TF_RETURN_IF_ERROR(
-        StoreDatasetInVariantTensor(input_dataset, &dataset_tensor));
-    Variant variant = dataset_tensor.scalar<Variant>()();
-    AddDatasetInputFromArray<Variant>(&map_inputs_, map_kernel_->input_types(),
-                                      TensorShape({}), {variant});
-
-    TF_RETURN_IF_ERROR(
-        InitOpKernelContext(map_kernel_.get(), &map_inputs_, &map_context_));
-    TF_RETURN_IF_ERROR(CheckOpKernelInput(*map_kernel_, map_inputs_));
-    TF_RETURN_IF_ERROR(RunOpKernel(map_kernel_.get(), map_context_.get()));
-    TF_RETURN_IF_ERROR(InitDatasetFromContext(map_context_.get(), output_index,
-                                              &map_dataset_));
-    return Status::OK();
+    return CreateOpKernel(map_node_def_);
   }
 
  protected:
-  NodeDef range_node_def_;
-  gtl::InlinedVector<TensorValue, 4> range_inputs_;
-  std::unique_ptr<OpKernel> range_kernel_;
   DatasetBase* range_dataset_;
-  std::unique_ptr<OpKernelContext> range_context_;
-
-  NodeDef map_node_def_;
   DatasetBase* map_dataset_;
-  gtl::InlinedVector<TensorValue, 4> map_inputs_;
   std::unique_ptr<OpKernel> map_kernel_;
   std::unique_ptr<OpKernelContext> map_context_;
   std::unique_ptr<IteratorContext> iterator_context_;
   std::unique_ptr<IteratorBase> iterator_;
-
   std::unique_ptr<SerializationContext> serialization_context_;
+
+ private:
+  NodeDef map_node_def_;
+  gtl::InlinedVector<TensorValue, 4> map_inputs_;
 };
 
 const char* MapDatasetOpTest::kNodeName = "map_dataset";
@@ -136,23 +106,25 @@ const char* MapDatasetOpTest::kOpName = "MapDataset";
 
 struct DatasetGetNextTest
     : MapDatasetOpTest,
-      ::testing::WithParamInterface<std::tuple<int, int, int>> {};
+      ::testing::WithParamInterface<
+          std::tuple<int64, int64, int64, string, std::vector<int64>,
+                     std::vector<FunctionDef>>> {};
 
 TEST_P(DatasetGetNextTest, GetNext) {
-  int output_index = 0, thread_num = 2, cpu_num = 2;
-  int start = std::get<0>(GetParam());
-  int end = std::get<1>(GetParam());
-  int step = std::get<2>(GetParam());
+  int thread_num = 2, cpu_num = 2;
+  int64 start = std::get<0>(GetParam());
+  int64 end = std::get<1>(GetParam());
+  int64 step = std::get<2>(GetParam());
+  string func_name = std::get<3>(GetParam());
+  std::vector<int64> expected_values = std::get<4>(GetParam());
+  std::vector<FunctionDef> func_lib = std::get<5>(GetParam());
+
   TF_ASSERT_OK(InitThreadPool(thread_num));
-  TF_ASSERT_OK(InitFunctionLibraryRuntime({MakeFuncDef()}, cpu_num));
-
-  TF_ASSERT_OK(MakeRangeDatasetOpKernel<int64>());
-  TF_ASSERT_OK(MakeRangeDataset(start, end, step, output_index));
-
-  TF_ASSERT_OK(MakeMapDatasetOpKernel<int64>());
-  TF_ASSERT_OK(MakeMapDataset(range_dataset_, 0));
-  TF_ASSERT_OK(MakeIterator(map_context_.get(), map_dataset_,
-                            &iterator_context_, &iterator_));
+  TF_ASSERT_OK(InitFunctionLibraryRuntime(func_lib, cpu_num));
+  range_dataset_ = CreateRangeDataset<int64>(start, end, step, "range");
+  map_dataset_ = CreateMapDataset(range_dataset_, func_name);
+  iterator_ =
+      CreateIterator(map_context_.get(), map_dataset_, &iterator_context_);
 
   bool end_of_sequence = false;
   std::vector<Tensor> out_tensors;
@@ -160,11 +132,7 @@ TEST_P(DatasetGetNextTest, GetNext) {
     TF_EXPECT_OK(GetNext(iterator_.get(), iterator_context_.get(), &out_tensors,
                          &end_of_sequence));
   }
-  std::vector<int64> expected_values;
-  for (int i = start; (end - i) * step > 0; i = i + step) {
-    expected_values.reserve(1);
-    expected_values.emplace_back(i * 2);
-  }
+
   EXPECT_EQ(out_tensors.size(), expected_values.size());
   for (size_t i = 0; i < out_tensors.size(); ++i) {
     int64 actual_value = out_tensors[i].flat<int64>()(0);
@@ -173,52 +141,52 @@ TEST_P(DatasetGetNextTest, GetNext) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(MapDatasetOpTest, DatasetGetNextTest,
-                        ::testing::Values(std::make_tuple(0, 10, 1),
-                                          std::make_tuple(0, 10, 3),
-                                          std::make_tuple(10, 0, -1),
-                                          std::make_tuple(10, 0, -3)));
+INSTANTIATE_TEST_CASE_P(
+    MapDatasetOpTest, DatasetGetNextTest,
+    ::testing::Values(
+        std::make_tuple(0, 10, 3, "XTimesTwo", std::vector<int64>{0, 6, 12, 18},
+                        std::vector<FunctionDef>{test::function::XTimesTwo()}),
+        std::make_tuple(0, 10, 3, "XAddX", std::vector<int64>{0, 6, 12, 18},
+                        std::vector<FunctionDef>{test::function::XAddX()}),
+        std::make_tuple(
+            10, 0, -3, "XTimesFour", std::vector<int64>{40, 28, 16, 4},
+            std::vector<FunctionDef>{test::function::XTimesTwo(),
+                                     test::function::XTimesFour()})));
 
 TEST_F(MapDatasetOpTest, DatasetName) {
-  int output_index = 0, thread_num = 2, cpu_num = 2;
-  int start = 0, end = 10, step = 1;
+  int thread_num = 2, cpu_num = 2;
+  int64 start = 0, end = 10, step = 1;
+  FunctionDef func_def = test::function::XTimesTwo();
+
   TF_ASSERT_OK(InitThreadPool(thread_num));
-  TF_ASSERT_OK(InitFunctionLibraryRuntime({MakeFuncDef()}, cpu_num));
-
-  TF_ASSERT_OK(MakeRangeDatasetOpKernel<int64>());
-  TF_ASSERT_OK(MakeRangeDataset(start, end, step, output_index));
-
-  TF_ASSERT_OK(MakeMapDatasetOpKernel<int64>());
-  TF_ASSERT_OK(MakeMapDataset(range_dataset_, 0));
+  TF_ASSERT_OK(InitFunctionLibraryRuntime({func_def}, cpu_num));
+  range_dataset_ = CreateRangeDataset<int64>(start, end, step, "range");
+  map_dataset_ = CreateMapDataset(range_dataset_, func_def.signature().name());
   EXPECT_EQ(map_dataset_->name(), kOpName);
 }
 
 TEST_F(MapDatasetOpTest, DatasetOutputDtypes) {
-  int output_index = 0, thread_num = 2, cpu_num = 2;
-  int start = 0, end = 10, step = 1;
+  int thread_num = 2, cpu_num = 2;
+  int64 start = 0, end = 10, step = 1;
+  FunctionDef func_def = test::function::XTimesTwo();
+
   TF_ASSERT_OK(InitThreadPool(thread_num));
-  TF_ASSERT_OK(InitFunctionLibraryRuntime({MakeFuncDef()}, cpu_num));
-
-  TF_ASSERT_OK(MakeRangeDatasetOpKernel<int64>());
-  TF_ASSERT_OK(MakeRangeDataset(start, end, step, output_index));
-
-  TF_ASSERT_OK(MakeMapDatasetOpKernel<int64>());
-  TF_ASSERT_OK(MakeMapDataset(range_dataset_, 0));
+  TF_ASSERT_OK(InitFunctionLibraryRuntime({func_def}, cpu_num));
+  range_dataset_ = CreateRangeDataset<int64>(start, end, step, "range");
+  map_dataset_ = CreateMapDataset(range_dataset_, func_def.signature().name());
   DataTypeVector expected_dtypes({DT_INT64});
   EXPECT_EQ(map_dataset_->output_dtypes(), expected_dtypes);
 }
 
 TEST_F(MapDatasetOpTest, DatasetOutputShapes) {
-  int output_index = 0, thread_num = 2, cpu_num = 2;
-  int start = 0, end = 10, step = 1;
+  int thread_num = 2, cpu_num = 2;
+  int64 start = 0, end = 10, step = 1;
+  FunctionDef func_def = test::function::XTimesTwo();
+
   TF_ASSERT_OK(InitThreadPool(thread_num));
-  TF_ASSERT_OK(InitFunctionLibraryRuntime({MakeFuncDef()}, cpu_num));
-
-  TF_ASSERT_OK(MakeRangeDatasetOpKernel<int64>());
-  TF_ASSERT_OK(MakeRangeDataset(start, end, step, output_index));
-
-  TF_ASSERT_OK(MakeMapDatasetOpKernel<int64>());
-  TF_ASSERT_OK(MakeMapDataset(range_dataset_, 0));
+  TF_ASSERT_OK(InitFunctionLibraryRuntime({func_def}, cpu_num));
+  range_dataset_ = CreateRangeDataset<int64>(start, end, step, "range");
+  map_dataset_ = CreateMapDataset(range_dataset_, func_def.signature().name());
   std::vector<PartialTensorShape> expected_shapes({{}});
   EXPECT_EQ(map_dataset_->output_shapes().size(), expected_shapes.size());
   for (int i = 0; i < map_dataset_->output_shapes().size(); ++i) {
@@ -228,22 +196,20 @@ TEST_F(MapDatasetOpTest, DatasetOutputShapes) {
 
 struct DatasetCardinalityTest
     : MapDatasetOpTest,
-      ::testing::WithParamInterface<std::tuple<int, int, int, int>> {};
+      ::testing::WithParamInterface<std::tuple<int64, int64, int64, int>> {};
 
 TEST_P(DatasetCardinalityTest, Cardinality) {
-  int output_index = 0, thread_num = 2, cpu_num = 2;
-  int start = std::get<0>(GetParam());
-  int end = std::get<1>(GetParam());
-  int step = std::get<2>(GetParam());
+  int thread_num = 2, cpu_num = 2;
+  int64 start = std::get<0>(GetParam());
+  int64 end = std::get<1>(GetParam());
+  int64 step = std::get<2>(GetParam());
   int expected_cardinality = std::get<3>(GetParam());
+  FunctionDef func_def = test::function::XTimesTwo();
+
   TF_ASSERT_OK(InitThreadPool(thread_num));
-  TF_ASSERT_OK(InitFunctionLibraryRuntime({MakeFuncDef()}, cpu_num));
-
-  TF_ASSERT_OK(MakeRangeDatasetOpKernel<int64>());
-  TF_ASSERT_OK(MakeRangeDataset(start, end, step, output_index));
-
-  TF_ASSERT_OK(MakeMapDatasetOpKernel<int64>());
-  TF_ASSERT_OK(MakeMapDataset(range_dataset_, 0));
+  TF_ASSERT_OK(InitFunctionLibraryRuntime({func_def}, cpu_num));
+  range_dataset_ = CreateRangeDataset<int64>(start, end, step, "range");
+  map_dataset_ = CreateMapDataset(range_dataset_, func_def.signature().name());
   EXPECT_EQ(map_dataset_->Cardinality(), expected_cardinality);
 }
 
@@ -253,18 +219,15 @@ INSTANTIATE_TEST_CASE_P(MapDatasetOpTest, DatasetCardinalityTest,
                                           std::make_tuple(10, 0, -3, 4)));
 
 TEST_F(MapDatasetOpTest, DatasetSave) {
-  int output_index = 0, thread_num = 2, cpu_num = 2;
-  int start = 0, end = 10, step = 1;
+  int thread_num = 2, cpu_num = 2;
+  int64 start = 0, end = 10, step = 1;
+  FunctionDef func_def = test::function::XTimesTwo();
+
   TF_ASSERT_OK(InitThreadPool(thread_num));
-  TF_ASSERT_OK(InitFunctionLibraryRuntime({MakeFuncDef()}, cpu_num));
-
-  TF_ASSERT_OK(MakeRangeDatasetOpKernel<int64>());
-  TF_ASSERT_OK(MakeRangeDataset(start, end, step, output_index));
-
-  TF_ASSERT_OK(MakeMapDatasetOpKernel<int64>());
-  TF_ASSERT_OK(MakeMapDataset(range_dataset_, 0));
-
-  InitSerializationContext(serialization_context_);
+  TF_ASSERT_OK(InitFunctionLibraryRuntime({func_def}, cpu_num));
+  range_dataset_ = CreateRangeDataset<int64>(start, end, step, "range");
+  map_dataset_ = CreateMapDataset(range_dataset_, func_def.signature().name());
+  serialization_context_ = CreateSerializationContext();
   VariantTensorData data;
   VariantTensorDataWriter writer(&data);
   TF_ASSERT_OK(map_dataset_->Save(serialization_context_.get(), &writer));
@@ -272,35 +235,33 @@ TEST_F(MapDatasetOpTest, DatasetSave) {
 }
 
 TEST_F(MapDatasetOpTest, IteratorOutputDtypes) {
-  int start = 0, end = 10, step = 1;
-  int output_index = 0, thread_num = 2, cpu_num = 2;
+  int64 start = 0, end = 10, step = 1;
+  int thread_num = 2, cpu_num = 2;
+  FunctionDef func_def = test::function::XTimesTwo();
+
   TF_ASSERT_OK(InitThreadPool(thread_num));
-  TF_ASSERT_OK(InitFunctionLibraryRuntime({MakeFuncDef()}, cpu_num));
+  TF_ASSERT_OK(InitFunctionLibraryRuntime({func_def}, cpu_num));
 
-  TF_ASSERT_OK(MakeRangeDatasetOpKernel<int64>());
-  TF_ASSERT_OK(MakeRangeDataset(start, end, step, output_index));
-
-  TF_ASSERT_OK(MakeMapDatasetOpKernel<int64>());
-  TF_ASSERT_OK(MakeMapDataset(range_dataset_, 0));
-  TF_ASSERT_OK(MakeIterator(map_context_.get(), map_dataset_,
-                            &iterator_context_, &iterator_));
+  range_dataset_ = CreateRangeDataset<int64>(start, end, step, "range");
+  map_dataset_ = CreateMapDataset(range_dataset_, func_def.signature().name());
+  iterator_ =
+      CreateIterator(map_context_.get(), map_dataset_, &iterator_context_);
   DataTypeVector expected_dtypes({DT_INT64});
   EXPECT_EQ(iterator_->output_dtypes(), expected_dtypes);
 }
 
 TEST_F(MapDatasetOpTest, IteratorOutputShapes) {
-  int start = 0, end = 10, step = 1;
-  int output_index = 0, thread_num = 2, cpu_num = 2;
+  int64 start = 0, end = 10, step = 1;
+  int thread_num = 2, cpu_num = 2;
+  FunctionDef func_def = test::function::XTimesTwo();
+
   TF_ASSERT_OK(InitThreadPool(thread_num));
-  TF_ASSERT_OK(InitFunctionLibraryRuntime({MakeFuncDef()}, cpu_num));
+  TF_ASSERT_OK(InitFunctionLibraryRuntime({func_def}, cpu_num));
 
-  TF_ASSERT_OK(MakeRangeDatasetOpKernel<int64>());
-  TF_ASSERT_OK(MakeRangeDataset(start, end, step, output_index));
-
-  TF_ASSERT_OK(MakeMapDatasetOpKernel<int64>());
-  TF_ASSERT_OK(MakeMapDataset(range_dataset_, 0));
-  TF_ASSERT_OK(MakeIterator(map_context_.get(), map_dataset_,
-                            &iterator_context_, &iterator_));
+  range_dataset_ = CreateRangeDataset<int64>(start, end, step, "range");
+  map_dataset_ = CreateMapDataset(range_dataset_, func_def.signature().name());
+  iterator_ =
+      CreateIterator(map_context_.get(), map_dataset_, &iterator_context_);
   std::vector<PartialTensorShape> expected_shapes({{}});
   EXPECT_EQ(iterator_->output_shapes().size(), expected_shapes.size());
   for (int i = 0; i < map_dataset_->output_shapes().size(); ++i) {
@@ -309,54 +270,50 @@ TEST_F(MapDatasetOpTest, IteratorOutputShapes) {
 }
 
 TEST_F(MapDatasetOpTest, IteratorOutputPrefix) {
-  int start = 0, end = 10, step = 1;
-  int output_index = 0, thread_num = 2, cpu_num = 2;
+  int64 start = 0, end = 10, step = 1;
+  int thread_num = 2, cpu_num = 2;
+  FunctionDef func_def = test::function::XTimesTwo();
+
   TF_ASSERT_OK(InitThreadPool(thread_num));
-  TF_ASSERT_OK(InitFunctionLibraryRuntime({MakeFuncDef()}, cpu_num));
+  TF_ASSERT_OK(InitFunctionLibraryRuntime({func_def}, cpu_num));
 
-  TF_ASSERT_OK(MakeRangeDatasetOpKernel<int64>());
-  TF_ASSERT_OK(MakeRangeDataset(start, end, step, output_index));
-
-  TF_ASSERT_OK(MakeMapDatasetOpKernel<int64>());
-  TF_ASSERT_OK(MakeMapDataset(range_dataset_, 0));
-  TF_ASSERT_OK(MakeIterator(map_context_.get(), map_dataset_,
-                            &iterator_context_, &iterator_));
+  range_dataset_ = CreateRangeDataset<int64>(start, end, step, "range");
+  map_dataset_ = CreateMapDataset(range_dataset_, func_def.signature().name());
+  iterator_ =
+      CreateIterator(map_context_.get(), map_dataset_, &iterator_context_);
   EXPECT_EQ(iterator_->prefix(), "Iterator::Map");
 }
 
 struct IteratorRoundtripTest
     : MapDatasetOpTest,
-      ::testing::WithParamInterface<std::tuple<int, int, int, int>> {};
+      ::testing::WithParamInterface<std::tuple<
+          int64, int64, int64, int, int64, string, std::vector<FunctionDef>>> {
+};
 
 TEST_P(IteratorRoundtripTest, Roundtrip) {
-  int output_index = 0, thread_num = 2, cpu_num = 2;
-  int start = std::get<0>(GetParam());
-  int end = std::get<1>(GetParam());
-  int step = std::get<2>(GetParam());
+  int thread_num = 2, cpu_num = 2;
+  int64 start = std::get<0>(GetParam());
+  int64 end = std::get<1>(GetParam());
+  int64 step = std::get<2>(GetParam());
   int breakpoint = std::get<3>(GetParam());
+  int64 expected_value = std::get<4>(GetParam());
+  string func_name = std::get<5>(GetParam());
+  std::vector<FunctionDef> func_lib = std::get<6>(GetParam());
+
   TF_ASSERT_OK(InitThreadPool(thread_num));
-  TF_ASSERT_OK(InitFunctionLibraryRuntime({MakeFuncDef()}, cpu_num));
+  TF_ASSERT_OK(InitFunctionLibraryRuntime(func_lib, cpu_num));
 
-  TF_ASSERT_OK(MakeRangeDatasetOpKernel<int64>());
-  TF_ASSERT_OK(MakeRangeDataset(start, end, step, output_index));
-
-  TF_ASSERT_OK(MakeMapDatasetOpKernel<int64>());
-  TF_ASSERT_OK(MakeMapDataset(range_dataset_, 0));
-  TF_ASSERT_OK(MakeIterator(map_context_.get(), map_dataset_,
-                            &iterator_context_, &iterator_));
+  range_dataset_ = CreateRangeDataset<int64>(start, end, step, "range");
+  map_dataset_ = CreateMapDataset(range_dataset_, func_name);
+  iterator_ =
+      CreateIterator(map_context_.get(), map_dataset_, &iterator_context_);
   std::vector<Tensor> out_tensors;
   bool end_of_sequence = false;
-  int cur_range_val = start - step;
   for (int i = 0; i < breakpoint; i++) {
-    if (!end_of_sequence) {
-      TF_EXPECT_OK(GetNext(iterator_.get(), iterator_context_.get(),
-                           &out_tensors, &end_of_sequence));
-      cur_range_val = ((end - cur_range_val - step) * step > 0)
-                          ? cur_range_val + step
-                          : cur_range_val;
-    }
+    TF_EXPECT_OK(GetNext(iterator_.get(), iterator_context_.get(), &out_tensors,
+                         &end_of_sequence));
   }
-  InitSerializationContext(serialization_context_);
+  serialization_context_ = CreateSerializationContext();
   VariantTensorData data;
   VariantTensorDataWriter writer(&data);
   TF_ASSERT_OK(iterator_->Save(serialization_context_.get(), &writer));
@@ -365,19 +322,20 @@ TEST_P(IteratorRoundtripTest, Roundtrip) {
   TF_ASSERT_OK(iterator_->Restore(iterator_context_.get(), &reader));
   TF_EXPECT_OK(GetNext(iterator_.get(), iterator_context_.get(), &out_tensors,
                        &end_of_sequence));
-  int expect_range_next = ((end - cur_range_val - step) * step > 0)
-                              ? cur_range_val + step
-                              : cur_range_val;
-  EXPECT_EQ(out_tensors.back().flat<int64>()(0), expect_range_next * 2);
+  EXPECT_EQ(out_tensors.back().flat<int64>()(0), expected_value);
 }
 
 INSTANTIATE_TEST_CASE_P(
     MapDatasetOpTest, IteratorRoundtripTest,
     ::testing::Values(
-        std::make_tuple(0, 10, 2, 0),    // unused_iterator
-        std::make_tuple(0, 10, 2, 4),    // fully_used_iterator_increase
-        std::make_tuple(10, 0, -2, 4),   // fully_used_iterator_decrease
-        std::make_tuple(0, 10, 2, 6)));  // exhausted_iterator
+        std::make_tuple(0, 10, 2, 0, 0, "XTimesTwo",
+                        std::vector<FunctionDef>{test::function::XTimesTwo()}),
+        std::make_tuple(0, 10, 2, 4, 16, "XAddX",
+                        std::vector<FunctionDef>{test::function::XAddX()}),
+        std::make_tuple(0, 10, 2, 6, 32, "XTimesFour",
+                        std::vector<FunctionDef>{
+                            test::function::XTimesTwo(),
+                            test::function::XTimesFour()})));
 
 }  // namespace
 }  // namespace data


### PR DESCRIPTION
This PR adds the tests for the public APIs of MapDataset C++ kernel.

Besides, it adds class `DatasetOpsTestBase` to provide the following utilities for testing Dataset kernels:

- prepare `TreadPool` and `FunctionLibraryRuntime`.

- make `OpKernelContext`, `OpKernel`, and run `OpKernel`.

- add inputs for `OpKernel` and get the output dataset from `OpKernelContext`.

- make `Dataset`, `Iterator`, and `IteratorContext`, and provide `GetNext`.

Besides, these API designs enable the subclass to own multiple kernels and datasets, which are necessary to run the tests for some `Dataset`s (e.g. MapDataset).



